### PR TITLE
fix numeric cast when calculating fileslide in symbols iter

### DIFF
--- a/Sources/MachOKit/MachO+Symbols.swift
+++ b/Sources/MachOKit/MachO+Symbols.swift
@@ -48,7 +48,7 @@ extension MachO {
             self.linkedit = linkedit
             self.symtab = symtab
 
-            self.fileSlide = numericCast(linkedit.vmaddr) - numericCast(text.vmaddr + linkedit.fileoff)
+            self.fileSlide = numericCast(linkedit.vmaddr) - numericCast(text.vmaddr) - numericCast(linkedit.fileoff)
         }
 
         public func makeIterator() -> Iterator {
@@ -88,7 +88,7 @@ extension MachO {
             self.linkedit = linkedit
             self.symtab = symtab
 
-            self.fileSlide = numericCast(linkedit.vmaddr) - numericCast(text.vmaddr + linkedit.fileoff)
+            self.fileSlide = numericCast(linkedit.vmaddr) - numericCast(text.vmaddr) - numericCast(linkedit.fileoff)
         }
 
         public func makeIterator() -> Iterator {


### PR DESCRIPTION
UInt -> Int
If the values are cast from unsigned to signed in a grouping, the values will be misaligned.