### PR TITLE
Remove unused params for MachOFile.Symbols

### DIFF
--- a/Sources/MachOKit/MachOFile+Symbols.swift
+++ b/Sources/MachOKit/MachOFile+Symbols.swift
@@ -24,8 +24,6 @@ extension MachOFile {
 extension MachOFile {
     public struct Symbols64: Sequence {
         let machO: MachOFile
-        public let text: SegmentCommand64
-        public let linkedit: SegmentCommand64
         public let symtab: LoadCommandInfo<symtab_command>
 
         public func makeIterator() -> Iterator {
@@ -135,8 +133,6 @@ extension MachOFile.Symbols64 {
 extension MachOFile {
     public struct Symbols: Sequence {
         let machO: MachOFile
-        public let text: SegmentCommand
-        public let linkedit: SegmentCommand
         public let symtab: LoadCommandInfo<symtab_command>
 
         public func makeIterator() -> Iterator {

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -113,13 +113,9 @@ extension MachOFile {
         guard is64Bit else {
             return nil
         }
-        if let text = loadCommands.text64,
-           let linkedit = loadCommands.linkedit64,
-           let symtab = loadCommands.symtab {
+        if let symtab = loadCommands.symtab {
             return Symbols64(
                 machO: self,
-                text: text,
-                linkedit: linkedit,
                 symtab: symtab
             )
         }
@@ -130,13 +126,9 @@ extension MachOFile {
         guard !is64Bit else {
             return nil
         }
-        if let text = loadCommands.text,
-           let linkedit = loadCommands.linkedit,
-           let symtab = loadCommands.symtab {
+        if let symtab = loadCommands.symtab {
             return Symbols(
                 machO: self,
-                text: text,
-                linkedit: linkedit,
                 symtab: symtab
             )
         }


### PR DESCRIPTION
There was a problem that symbols could not be obtained because Text segments, etc. did not exist at the object file stage.