### PR TITLE
Fixed Tuple to String conversion

### DIFF
--- a/Sources/MachOKit/Extension/String+.swift
+++ b/Sources/MachOKit/Extension/String+.swift
@@ -13,7 +13,10 @@ extension String {
 
     init(tuple: CCharTuple16) {
         var buffer = tuple
-        self = withUnsafePointer(to: &buffer.0) { String(cString: $0) }
+        self = withUnsafePointer(to: &buffer.0) {
+            let data = Data(bytes: $0, count: 16) + [0]
+            return String(cString: data)!
+        }
     }
 }
 
@@ -22,6 +25,19 @@ extension String {
 
     init(tuple: CCharTuple32) {
         var buffer = tuple
-        self = withUnsafePointer(to: &buffer.0) { String(cString: $0) }
+        self = withUnsafePointer(to: &buffer.0) {
+            let data = Data(bytes: $0, count: 32) + [0]
+            return String(cString: data)!
+        }
+    }
+}
+
+extension String {
+    init?(cString data: Data) {
+        guard !data.isEmpty else { return nil }
+        self = data.withUnsafeBytes {
+            let ptr = $0.baseAddress!.assumingMemoryBound(to: CChar.self)
+            return String(cString: ptr)
+        }
     }
 }


### PR DESCRIPTION
When the number of characters is the same as the size of the tuple, the null terminator is not included.