### PR TITLE
Add option to search only global symbols

### DIFF
--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -24,10 +24,14 @@ extension MachOImage {
 
 extension MachOImage {
     public static func closestSymbol(
-        at address: UnsafeRawPointer
+        at address: UnsafeRawPointer,
+        isGlobalOnly: Bool = false
     ) -> (MachOImage, Symbol)? {
         for image in images where image.contains(address) {
-            if let symbol = image.closestSymbol(at: address) {
+            if let symbol = image.closestSymbol(
+                at: address,
+                isGlobalOnly: isGlobalOnly
+            ) {
                 return (image, symbol)
             }
         }
@@ -62,17 +66,24 @@ extension MachOImage {
         }
 
         guard let closestImage,
-              let symbol = closestImage.closestSymbol(at: address) else {
+              let symbol = closestImage.closestSymbol(
+                at: address,
+                isGlobalOnly: isGlobalOnly
+              ) else {
             return nil
         }
         return (closestImage, symbol)
     }
 
     public static func symbol(
-        for address: UnsafeRawPointer
+        for address: UnsafeRawPointer,
+        isGlobalOnly: Bool = false
     ) -> (MachOImage, Symbol)? {
         for image in images where image.contains(address) {
-            if let symbol = image.symbol(for: address) {
+            if let symbol = image.symbol(
+                for: address,
+                isGlobalOnly: isGlobalOnly
+            ) {
                 return (image, symbol)
             }
         }

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -435,24 +435,32 @@ extension MachOImage {
     /// - Parameters:
     ///   - address: Address to find closest symbol.
     ///   - sectionNumber: Section number to be searched.
+    ///   - isGlobalOnly: If true, search only global symbols.
     /// - Returns: Closest symbol.
     public func closestSymbol(
         at address: UnsafeRawPointer,
-        inSection sectionNumber: Int = 0
+        inSection sectionNumber: Int = 0,
+        isGlobalOnly: Bool = false
     ) -> Symbol? {
         let offset = Int(bitPattern: address) - Int(bitPattern: ptr)
         return closestSymbol(
             at: offset,
-            inSection: sectionNumber
+            inSection: sectionNumber,
+            isGlobalOnly: isGlobalOnly
         )
     }
 
     /// Find symbols matching the specified address.
-    /// - Parameter address: Address to find matching symbol.
+    /// - Parameters:
+    ///   -  address: Address to find matching symbol.
+    ///   - isGlobalOnly: If true, search only global symbols.
     /// - Returns: Matched symbol
-    public func symbol(for address: UnsafeRawPointer) -> Symbol? {
+    public func symbol(
+        for address: UnsafeRawPointer,
+        isGlobalOnly: Bool = false
+    ) -> Symbol? {
         let offset = Int(bitPattern: address) - Int(bitPattern: ptr)
-        return symbol(for: offset)
+        return symbol(for: offset, isGlobalOnly: isGlobalOnly)
     }
 }
 


### PR DESCRIPTION
`dladdr` function excludes local symbols from the search

https://github.com/apple-oss-distributions/Libwrappers/blob/main/dlcompat/dlfcn.c#L1145