### PR TITLE
Hide exported module's symbols from docc

### DIFF
--- a/Sources/MachOKit/Util/exported.swift
+++ b/Sources/MachOKit/Util/exported.swift
@@ -6,5 +6,10 @@
 //  
 //
 
-@_exported import MachO
-@_exported import MachOKitC
+@_documentation(visibility: internal) 
+@_exported 
+import MachO
+
+@_documentation(visibility: internal)
+@_exported 
+import MachOKitC


### PR DESCRIPTION
MachOKit imports exported MachO modules.
In this case, DocC also displays the symbols defined in the MachO module.


The following attributes are used to display only the symbols defined in MachOKit.
https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_documentationvisibility-

<img width="1192" alt="image" src="https://github.com/p-x9/MachOKit/assets/50244599/913ba8dd-805d-443e-ae22-e693e6f20443">
