### PR TITLE
Add some properties to Segment/Section protocol

### DIFF
--- a/Sources/MachOKit/LoadCommand/Model/Section.swift
+++ b/Sources/MachOKit/LoadCommand/Model/Section.swift
@@ -11,8 +11,9 @@ import Foundation
 public protocol SectionProtocol: LayoutWrapper {
     var sectionName: String { get }
     var segmentName: String { get }
-    var offset: Int { get }
+    var address: Int { get }
     var size: Int { get }
+    var offset: Int { get }
     var flags: SectionFlags { get }
 
     var indirectSymbolIndex: Int? { get }
@@ -64,12 +65,16 @@ extension Section {
         .init(tuple: layout.segname)
     }
 
-    public var offset: Int {
-        numericCast(layout.offset)
+    public var address: Int {
+        numericCast(layout.addr)
     }
 
     public var size: Int {
         numericCast(layout.size)
+    }
+
+    public var offset: Int {
+        numericCast(layout.offset)
     }
 
     public var flags: SectionFlags {
@@ -118,12 +123,16 @@ extension Section64 {
         .init(tuple: layout.segname)
     }
 
-    public var offset: Int {
-        numericCast(layout.offset)
+    public var address: Int {
+        numericCast(layout.addr)
     }
 
     public var size: Int {
         numericCast(layout.size)
+    }
+
+    public var offset: Int {
+        numericCast(layout.offset)
     }
 
     public var flags: SectionFlags {

--- a/Sources/MachOKit/LoadCommand/SegmentCommand.swift
+++ b/Sources/MachOKit/LoadCommand/SegmentCommand.swift
@@ -17,6 +17,7 @@ public protocol SegmentCommandProtocol: LoadCommandWrapper {
     var fileSize: Int { get }
     var maxProtection: VMProtection { get }
     var initialProtection: VMProtection { get }
+    var numberOfSections: Int { get }
     var flags: SegmentCommandFlags { get }
 
     func startPtr(vmaddrSlide: Int) -> UnsafeRawPointer?
@@ -76,6 +77,10 @@ public struct SegmentCommand: SegmentCommandProtocol {
         .init(rawValue: layout.initprot)
     }
 
+    public var numberOfSections: Int {
+        numericCast(layout.nsects)
+    }
+
     public var flags: SegmentCommandFlags {
         .init(rawValue: layout.flags)
     }
@@ -119,6 +124,10 @@ public struct SegmentCommand64: SegmentCommandProtocol {
 
     public var initialProtection: VMProtection {
         .init(rawValue: layout.initprot)
+    }
+
+    public var numberOfSections: Int {
+        numericCast(layout.nsects)
     }
 
     public var flags: SegmentCommandFlags {


### PR DESCRIPTION
There were properties between SegmentCommand and SegmentCommand64, and Section and Section64 that were common but not added to the protocol.