### PR TITLE
Add a flag to check if the machO file is loaded from the dyld cache

### DIFF
--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -447,3 +447,10 @@ extension MachOFile {
         return .init(data: data)
     }
 }
+
+extension MachOFile {
+    /// A Boolean value that indicates whether this machO file was loaded from dyld cache
+    public var isLoadedFromDyldCache: Bool {
+        headerStartOffsetInCache > 0
+    }
+}


### PR DESCRIPTION
Add a flag to check if the machO file is loaded from the dyld cache.
When this value is true, `url` indicates the path of the dyld cache file