### PR TITLE
Support programs trie in dyld cache

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -198,14 +198,13 @@ extension DyldCache {
     ///
     /// The ``programOffsets`` are retrieved from this trie tree．
     public var programsTrieEntries: ProgramsTrieEntries? {
-        let cache1 = try! DyldCache(url: url.appendingPathExtension("01"))
-        guard let offset = cache1.fileOffset(of: header.programTrieAddr) else {
+        guard let offset = fileOffset(of: header.programTrieAddr) else {
             return nil
         }
         let size = header.programTrieSize
 
         return ProgramsTrieEntries(
-            data: cache1.fileHandle.readData(offset: offset, size: Int(size))
+            data: fileHandle.readData(offset: offset, size: Int(size))
         )
     }
 
@@ -229,12 +228,11 @@ extension DyldCache {
     /// - Parameter programOffset: program name and offset pair
     /// - Returns: prebuiltLoaderSet
     public func prebuiltLoaderSet(for programOffset: ProgramOffset) -> PrebuiltLoaderSet? {
-        let cache1 = try! DyldCache(url: url.appendingPathExtension("01"))
         let address: Int = numericCast(header.programsPBLSetPoolAddr) + numericCast(programOffset.offset)
-        guard let offset = cache1.fileOffset(
-            of: numericCast(address)
-        ) else { return nil }
-        let layout: prebuilt_loader_set = cache1.fileHandle.read(
+        guard let offset = fileOffset(of: numericCast(address)) else {
+            return nil
+        }
+        let layout: prebuilt_loader_set = fileHandle.read(
             offset: offset
         )
         return .init(layout: layout, address: address)

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -192,6 +192,41 @@ extension DyldCache {
 }
 
 extension DyldCache {
+    public typealias ProgramsTrieEntries = DataTrieTree<ProgramsTrieNodeContent>
+
+    /// Pair of program name/cdhash and offset to prebuiltLoaderSet
+    ///
+    /// The ``programOffsets`` are retrieved from this trie tree．
+    public var programsTrieEntries: ProgramsTrieEntries? {
+        let cache1 = try! DyldCache(url: url.appendingPathExtension("01"))
+        guard let offset = cache1.fileOffset(of: header.programTrieAddr) else {
+            return nil
+        }
+        let size = header.programTrieSize
+
+        return ProgramsTrieEntries(
+            data: cache1.fileHandle.readData(offset: offset, size: Int(size))
+        )
+    }
+
+    /// Pair of program name/cdhash and offset to prebuiltLoaderSet
+    ///
+    /// Example:
+    /// ```
+    /// 0 /System/Applications/App Store.app/Contents/MacOS/App Store
+    /// 0 /cdhash/32caa391186c08b3b3cb7866995db1cb65b0376a
+    /// 131776 /System/Applications/Automator.app/Contents/MacOS/Automator
+    /// 131776 /cdhash/fed26a75645fed2a674b5c4d01001bfa69b9dbea
+    /// ```
+    public var programOffsets: [ProgramOffset] {
+        guard let programsTrieEntries else {
+            return []
+        }
+        return programsTrieEntries.programOffsets
+    }
+}
+
+extension DyldCache {
     public var objcOptimization: ObjCOptimization? {
         let sharedRegionStart = header.sharedRegionStart
         guard let offset = fileOffset(

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -224,6 +224,21 @@ extension DyldCache {
         }
         return programsTrieEntries.programOffsets
     }
+
+    /// Get the prebuiltLoaderSet indicated by programOffset.
+    /// - Parameter programOffset: program name and offset pair
+    /// - Returns: prebuiltLoaderSet
+    public func prebuiltLoaderSet(for programOffset: ProgramOffset) -> PrebuiltLoaderSet? {
+        let cache1 = try! DyldCache(url: url.appendingPathExtension("01"))
+        let address: Int = numericCast(header.programsPBLSetPoolAddr) + numericCast(programOffset.offset)
+        guard let offset = cache1.fileOffset(
+            of: numericCast(address)
+        ) else { return nil }
+        let layout: prebuilt_loader_set = cache1.fileHandle.read(
+            offset: offset
+        )
+        return .init(layout: layout, address: address)
+    }
 }
 
 extension DyldCache {

--- a/Sources/MachOKit/Model/DyldCache/Loader/LoaderRef.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/LoaderRef.swift
@@ -1,0 +1,29 @@
+//
+//  LoaderRef.swift
+//
+//
+//  Created by p-x9 on 2024/07/10
+//  
+//
+
+import Foundation
+
+public struct LoaderRef: LayoutWrapper {
+    public typealias Layout = loader_ref
+
+    public var layout: Layout
+}
+
+extension LoaderRef {
+    public var index: Int {
+        numericCast(layout.index)
+    }
+
+    public var isApp: Bool {
+        layout.app == 1
+    }
+
+    public var  isDylib: Bool {
+        layout.app == 0
+    }
+}

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
@@ -16,10 +16,32 @@ public struct PrebuiltLoader: LayoutWrapper {
 }
 
 extension PrebuiltLoader {
+    // always true
+    public var isPrebuilt: Bool {
+        layout.isPrebuilt != 0
+    }
+
+    public var ref: LoaderRef {
+        .init(layout: layout.ref)
+    }
+
     public func path(in cache: DyldCache) -> String? {
         guard let offset = cache.fileOffset(
             of: numericCast(address) + numericCast(layout.pathOffset)
         ) else { return nil }
         return cache.fileHandle.readString(offset: offset)
+    }
+
+    public func dependentLoaderRefs(in cache: DyldCache) -> DataSequence<LoaderRef>? {
+        guard layout.dependentLoaderRefsArrayOffset != 0,
+              let offset = cache.fileOffset(
+                of: numericCast(address) + numericCast(layout.dependentLoaderRefsArrayOffset)
+              ) else {
+            return nil
+        }
+        return cache.fileHandle.readDataSequence(
+            offset: offset,
+            numberOfElements: numericCast(layout.depCount)
+        )
     }
 }

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
@@ -1,0 +1,25 @@
+//
+//  PrebuiltLoader.swift
+//  
+//
+//  Created by p-x9 on 2024/07/09
+//  
+//
+
+import Foundation
+
+public struct PrebuiltLoader: LayoutWrapper {
+    public typealias Layout = prebuilt_loader
+
+    public var layout: Layout
+    public var address: Int
+}
+
+extension PrebuiltLoader {
+    public func path(in cache: DyldCache) -> String? {
+        guard let offset = cache.fileOffset(
+            of: numericCast(address) + numericCast(layout.pathOffset)
+        ) else { return nil }
+        return cache.fileHandle.readString(offset: offset)
+    }
+}

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
@@ -43,3 +43,16 @@ extension PrebuiltLoaderSet {
         }
     }
 }
+
+extension PrebuiltLoaderSet {
+    public func dyldCacheUUID(in cache: DyldCache) -> UUID? {
+        guard layout.dyldCacheUUIDOffset != 0,
+              let offset = cache.fileOffset(
+            of: numericCast(address) + numericCast(layout.dyldCacheUUIDOffset)
+        ) else {
+            return nil
+        }
+        let data: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = cache.fileHandle.read(offset: offset)
+        return .init(uuid: data)
+    }
+}

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
@@ -55,4 +55,22 @@ extension PrebuiltLoaderSet {
         let data: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = cache.fileHandle.read(offset: offset)
         return .init(uuid: data)
     }
+
+    public func mustBeMissingPaths(in cache: DyldCache) -> [String]? {
+        guard layout.mustBeMissingPathsOffset != 0,
+              var offset = cache.fileOffset(
+                of: numericCast(address) + numericCast(layout.mustBeMissingPathsOffset)
+              ) else {
+            return nil
+        }
+        var strings: [String] = []
+        for _ in 0 ..< layout.mustBeMissingPathsCount {
+            guard let string = cache.fileHandle.readString(offset: offset) else {
+                break
+            }
+            strings.append(string)
+            offset += UInt64(string.utf8.count) + 1 // \0
+        }
+        return strings
+    }
 }

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
@@ -1,0 +1,45 @@
+//
+//  PrebuiltLoaderSet.swift
+//
+//
+//  Created by p-x9 on 2024/07/09
+//
+//
+
+import Foundation
+
+public struct PrebuiltLoaderSet: LayoutWrapper {
+    public typealias Layout = prebuilt_loader_set
+
+    public var layout: Layout
+    public var address: Int
+}
+
+extension PrebuiltLoaderSet {
+    public func loaders(in cache: DyldCache) -> [PrebuiltLoader]? {
+        guard let offset = cache.fileOffset(of: numericCast(address)) else {
+            return nil
+        }
+        let offsets: DataSequence<UInt32> = cache.fileHandle.readDataSequence(
+            offset: offset + numericCast(layout.loadersArrayOffset),
+            numberOfElements: numericCast(layout.loadersArrayCount)
+        )
+        return offsets.compactMap { _offset -> PrebuiltLoader? in
+            guard let offset = cache.fileOffset(
+                of: numericCast(address) + numericCast(_offset)
+            ) else {
+                return nil
+            }
+            return cache.fileHandle.readData(
+                offset: numericCast(offset),
+                size: PrebuiltLoader.layoutSize
+            ).withUnsafeBytes {
+                let loader = $0.load(as: prebuilt_loader.self)
+                return PrebuiltLoader(
+                    layout: loader,
+                    address: address + numericCast(_offset)
+                )
+            }
+        }
+    }
+}

--- a/Sources/MachOKit/Model/DyldCache/ProgramOffset.swift
+++ b/Sources/MachOKit/Model/DyldCache/ProgramOffset.swift
@@ -1,0 +1,14 @@
+//
+//  ProgramOffset.swift
+//
+//
+//  Created by p-x9 on 2024/07/09
+//  
+//
+
+import Foundation
+
+public struct ProgramOffset {
+    public let name: String
+    public let offset: UInt32
+}

--- a/Sources/MachOKit/Model/DyldCache/ProgramsTrieNodeContent.swift
+++ b/Sources/MachOKit/Model/DyldCache/ProgramsTrieNodeContent.swift
@@ -1,0 +1,31 @@
+//
+//  ProgramsTrieNodeContent.swift
+//
+//
+//  Created by p-x9 on 2024/07/09
+//  
+//
+
+import Foundation
+
+public typealias ProgramsTrieEntry = TrieNode<ProgramsTrieNodeContent>
+
+public struct ProgramsTrieNodeContent {
+    public let offset: UInt32
+}
+
+extension ProgramsTrieNodeContent: TrieNodeContent {
+    public static func read(
+        basePointer: UnsafePointer<UInt8>,
+        trieSize: Int,
+        nextOffset: inout Int
+    ) -> ProgramsTrieNodeContent? {
+        let (offset, ulebOffset) = basePointer
+            .advanced(by: nextOffset)
+            .readULEB128()
+
+        nextOffset += ulebOffset
+
+        return .init(offset: numericCast(offset))
+    }
+}

--- a/Sources/MachOKitC/include/dyld_cache_loader.h
+++ b/Sources/MachOKitC/include/dyld_cache_loader.h
@@ -1,0 +1,113 @@
+//
+//  dyld_cache_loader.h
+//
+//
+//  Created by p-x9 on 2024/07/09
+//  
+//
+
+#ifndef dyld_cache_loader_h
+#define dyld_cache_loader_h
+
+// https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/dyld/PrebuiltLoader.h#L254
+struct prebuilt_loader_set {
+    uint32_t    magic;
+    uint32_t    versionHash;   // PREBUILTLOADER_VERSION
+    uint32_t    length;
+    uint32_t    loadersArrayCount;
+    uint32_t    loadersArrayOffset;
+    uint32_t    cachePatchCount;
+    uint32_t    cachePatchOffset;
+    uint32_t    dyldCacheUUIDOffset;
+    uint32_t    mustBeMissingPathsCount;
+    uint32_t    mustBeMissingPathsOffset;
+    // ObjC prebuilt data
+    uint32_t    objcSelectorHashTableOffset;
+    uint32_t    objcClassHashTableOffset;
+    uint32_t    objcProtocolHashTableOffset;
+    uint32_t    reserved;
+    uint64_t    objcProtocolClassCacheOffset;
+    // Swift prebuilt data
+    uint32_t    swiftTypeConformanceTableOffset;
+    uint32_t    swiftMetadataConformanceTableOffset;
+    uint32_t    swiftForeignTypeConformanceTableOffset;
+};
+
+struct loader_ref {
+    uint16_t    index       : 15,   // index into PrebuiltLoaderSet
+                app         :  1;   // app vs dyld cache PrebuiltLoaderSet
+};
+
+struct code_signature_in_file
+{
+    uint32_t   fileOffset;
+    uint32_t   size;
+};
+
+// https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/dyld/Loader.h#L71
+// https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/include/mach-o/dyld_priv.h#L89
+struct section_locations {
+    uint32_t version;
+    uint32_t flags;
+
+    uint64_t offsets[21 /* _dyld_section_location_count */];
+    uint64_t sizes[21];
+};
+
+// ref: https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/dyld/PrebuiltLoader.h#L83
+struct prebuilt_loader {
+    // Loader
+    const uint32_t      magic;                    // kMagic
+    const uint16_t      isPrebuilt         :  1,  // PrebuiltLoader vs JustInTimeLoader
+                        dylibInDyldCache   :  1,
+                        hasObjC            :  1,
+                        mayHavePlusLoad    :  1,
+                        hasReadOnlyData    :  1,  // __DATA_CONST.  Don't use directly.  Use hasConstantSegmentsToProtect()
+                        neverUnload        :  1,  // part of launch or has non-unloadable data (e.g. objc, tlv)
+                        leaveMapped        :  1,  // RTLD_NODELETE
+                        hasReadOnlyObjC    :  1,  // Has __DATA_CONST,__objc_selrefs section
+                        pre2022Binary      :  1,
+                        isPremapped        :  1,  // mapped by exclave core
+                        padding            :  6;
+    struct loader_ref ref;
+
+    // Main
+    uint16_t            pathOffset;
+    uint16_t            dependentLoaderRefsArrayOffset; // offset to array of LoaderRef
+    uint16_t            dependentKindArrayOffset;       // zero if all deps normal
+    uint16_t            fixupsLoadCommandOffset;
+
+    uint16_t            altPathOffset;                  // if install_name does not match real path
+    uint16_t            fileValidationOffset;           // zero or offset to FileValidationInfo
+
+    uint16_t            hasInitializers      :  1,
+                        isOverridable        :  1,      // if in dyld cache, can roots override it
+                        supportsCatalyst     :  1,      // if false, this cannot be used in catalyst process
+                        isCatalystOverride   :  1,      // catalyst side of unzippered twin
+                        regionsCount         : 12;
+    uint16_t            regionsOffset;                  // offset to Region array
+
+    uint16_t            depCount;
+    uint16_t            bindTargetRefsOffset;
+    uint32_t            bindTargetRefsCount;            // bind targets can be large, so it is last
+    // After this point, all offsets in to the PrebuiltLoader need to be 32-bits as the bind targets can be large
+
+    uint32_t            objcBinaryInfoOffset;           // zero or offset to ObjCBinaryInfo
+    uint16_t            indexOfTwin;                    // if in dyld cache and part of unzippered twin, then index of the other twin
+    uint16_t            reserved1;
+
+    uint64_t            exportsTrieLoaderOffset;
+    uint32_t            exportsTrieLoaderSize;
+    uint32_t            vmSpace;
+
+    struct code_signature_in_file codeSignature;
+
+    uint32_t            patchTableOffset;
+
+    uint32_t            overrideBindTargetRefsOffset;
+    uint32_t            overrideBindTargetRefsCount;
+
+    // struct section_locations    sectionLocations;
+};
+
+#endif /* dyld_cache_loader_h */

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -164,6 +164,30 @@ final class DyldCachePrintTests: XCTestCase {
         }
     }
 
+    func testProgramOffsets() {
+        let programOffsets = cache.programOffsets
+        for programOffset in programOffsets {
+            print(programOffset.offset, programOffset.name)
+        }
+    }
+
+    func testProgramPreBuildLoaderSet() {
+        let programOffsets = cache.programOffsets
+        for programOffset in programOffsets {
+            guard !programOffset.name.starts(with: "/cdhash") else {
+                continue
+            }
+            guard let loaderSet = cache.prebuiltLoaderSet(for: programOffset) else {
+                continue
+            }
+            print("Name:", programOffset.name)
+            print("Loaders:")
+            for loader in loaderSet.loaders(in: cache1)! {
+                print("  \(loader.path(in: cache1) ?? "unknown")")
+            }
+        }
+    }
+
     func testObjCOptimization() throws {
         guard let objcOptimization = cache.objcOptimization else { return }
         print("Version:", objcOptimization.version)

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -182,8 +182,8 @@ final class DyldCachePrintTests: XCTestCase {
             }
             print("Name:", programOffset.name)
             print("Loaders:")
-            for loader in loaderSet.loaders(in: cache1)! {
-                print("  \(loader.path(in: cache1) ?? "unknown")")
+            for loader in loaderSet.loaders(in: cache)! {
+                print("  \(loader.path(in: cache) ?? "unknown")")
             }
         }
     }


### PR DESCRIPTION
```c
    uint64_t    programsPBLSetPoolAddr;     // (unslid) address of pool of PrebuiltLoaderSet for each program
    uint64_t    programsPBLSetPoolSize;     // size of pool of PrebuiltLoaderSet for each program
    uint64_t    programTrieAddr;            // (unslid) address of trie mapping program path to PrebuiltLoaderSet
    uint32_t    programTrieSize;
```