### PR TITLE
Dyld Sub Cache loading

### DIFF
--- a/Sources/MachOKit/DyldCache+SubCaches.swift
+++ b/Sources/MachOKit/DyldCache+SubCaches.swift
@@ -66,7 +66,7 @@ extension DyldCache.SubCaches {
                     let ptr = UnsafeMutableRawPointer(mutating: baseAddress)
                         .advanced(by: nextOffset)
                         .assumingMemoryBound(to: DyldSubCacheEntryGeneral.Layout.self)
-                    return .general(.init(layout: ptr.pointee))
+                    return .general(.init(layout: ptr.pointee, index: nextIndex))
                 }
             case .v1:
                 return data.withUnsafeBytes {
@@ -75,7 +75,7 @@ extension DyldCache.SubCaches {
                     let ptr = UnsafeMutableRawPointer(mutating: baseAddress)
                         .advanced(by: nextOffset)
                         .assumingMemoryBound(to: DyldSubCacheEntryV1.Layout.self)
-                    return .v1(.init(layout: ptr.pointee))
+                    return .v1(.init(layout: ptr.pointee, index: nextIndex))
                 }
             }
         }

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -122,9 +122,10 @@ extension DyldCache {
             return nil
         }
 
-        let subCache: DyldSubCacheEntryGeneral = fileHandle.read(
+        let layout: DyldSubCacheEntryGeneral.Layout = fileHandle.read(
             offset: numericCast(header.subCacheArrayOffset)
         )
+        let subCache = DyldSubCacheEntryGeneral(layout: layout, index: 0)
 
         if subCache.fileSuffix.starts(with: ".") {
             return .general
@@ -190,10 +191,10 @@ extension DyldCache {
     ///
     /// The ``dylibIndices`` are retrieved from this trie tree．
     public var dylibsTrieEntries: DylibsTrieEntries? {
-        guard let offset = fileOffset(of: header.dylibsTrieAddr) else {
+        guard let offset = fileOffset(of: mainCacheHeader.dylibsTrieAddr) else {
             return nil
         }
-        let size = header.dylibsTrieSize
+        let size = mainCacheHeader.dylibsTrieSize
 
         return DataTrieTree<DylibsTrieNodeContent>(
             data: fileHandle.readData(offset: offset, size: Int(size))
@@ -224,10 +225,10 @@ extension DyldCache {
     ///
     /// The ``programOffsets`` are retrieved from this trie tree．
     public var programsTrieEntries: ProgramsTrieEntries? {
-        guard let offset = fileOffset(of: header.programTrieAddr) else {
+        guard let offset = fileOffset(of: mainCacheHeader.programTrieAddr) else {
             return nil
         }
-        let size = header.programTrieSize
+        let size = mainCacheHeader.programTrieSize
 
         return ProgramsTrieEntries(
             data: fileHandle.readData(offset: offset, size: Int(size))
@@ -254,7 +255,7 @@ extension DyldCache {
     /// - Parameter programOffset: program name and offset pair
     /// - Returns: prebuiltLoaderSet
     public func prebuiltLoaderSet(for programOffset: ProgramOffset) -> PrebuiltLoaderSet? {
-        let address: Int = numericCast(header.programsPBLSetPoolAddr) + numericCast(programOffset.offset)
+        let address: Int = numericCast(mainCacheHeader.programsPBLSetPoolAddr) + numericCast(programOffset.offset)
         guard let offset = fileOffset(of: numericCast(address)) else {
             return nil
         }
@@ -267,7 +268,7 @@ extension DyldCache {
 
 extension DyldCache {
     public var dylibsPrebuiltLoaderSet: PrebuiltLoaderSet? {
-        let address: Int = numericCast(header.dylibsPBLSetAddr)
+        let address: Int = numericCast(mainCacheHeader.dylibsPBLSetAddr)
         guard let offset = fileOffset(of: numericCast(address)) else {
             return nil
         }
@@ -280,9 +281,9 @@ extension DyldCache {
 
 extension DyldCache {
     public var objcOptimization: ObjCOptimization? {
-        let sharedRegionStart = header.sharedRegionStart
+        let sharedRegionStart = mainCacheHeader.sharedRegionStart
         guard let offset = fileOffset(
-            of: sharedRegionStart + numericCast(header.objcOptsOffset)
+            of: sharedRegionStart + numericCast(mainCacheHeader.objcOptsOffset)
         ) else {
             return nil
         }
@@ -290,9 +291,9 @@ extension DyldCache {
     }
 
     public var swiftOptimization: SwiftOptimization? {
-        let sharedRegionStart = header.sharedRegionStart
+        let sharedRegionStart = mainCacheHeader.sharedRegionStart
         guard let offset = fileOffset(
-            of: sharedRegionStart + numericCast(header.swiftOptsOffset)
+            of: sharedRegionStart + numericCast(mainCacheHeader.swiftOptsOffset)
         ) else {
             return nil
         }

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -25,6 +25,20 @@ public class DyldCache {
     /// It is obtained based on magic.
     public let cpu: CPU
 
+    private var _mainCacheHeader: DyldCacheHeader?
+
+    /// Header for main dyld cache
+    /// When this dyld cache is a subcache, represent the header of the main cache
+    ///
+    /// Some properties are only set for the main cache header
+    /// https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/cache_builder/SubCache.cpp#L1353
+    public var mainCacheHeader: DyldCacheHeader {
+        _mainCacheHeader ?? header
+    }
+    
+    /// Load dyld cache.
+    /// - Parameter url: url for dyld cache
+    /// - Important: Use ``init(subcacheUrl:mainCacheHeader:)`` to load sub cache
     public init(url: URL) throws {
         self.url = url
         let fileHandle = try FileHandle(forReadingFrom: url)
@@ -44,6 +58,18 @@ public class DyldCache {
             typeRawValue: cpuType.rawValue,
             subtypeRawValue: cpuSubType.rawValue
         )
+    }
+
+    /// Load sub dyld cache
+    /// - Parameters:
+    ///   - subcacheUrl: url for dyld cache
+    ///   - mainCacheHeader: header of main dyld cache
+    public convenience init(
+        subcacheUrl: URL,
+        mainCacheHeader: DyldCacheHeader
+    ) throws {
+        try self.init(url: subcacheUrl)
+        self._mainCacheHeader = mainCacheHeader
     }
 
     deinit {

--- a/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
@@ -52,11 +52,19 @@ public enum DyldSubCacheEntry {
     /// File name suffix of the subCache file
     ///
     /// e.g. ".25.data", ".03.development"
-    public var fileSuffix: String? {
+    public var fileSuffix: String {
         switch self {
         case let .general(info): info.fileSuffix
-        case .v1: nil
+        case let .v1(info): info.fileSuffix
         }
+    }
+}
+
+// cache
+extension DyldSubCacheEntry {
+    func subcache(for cache: DyldCache) throws -> DyldCache? {
+        let url = URL(fileURLWithPath: cache.url.path + fileSuffix)
+        return try DyldCache(subcacheUrl: url, mainCacheHeader: cache.header)
     }
 }
 
@@ -64,6 +72,7 @@ public struct DyldSubCacheEntryV1: LayoutWrapper {
     public typealias Layout = dyld_subcache_entry_v1
 
     public var layout: Layout
+    public let index: Int
 }
 
 extension DyldSubCacheEntryV1 {
@@ -71,12 +80,20 @@ extension DyldSubCacheEntryV1 {
     public var uuid: UUID {
         .init(uuid: layout.uuid)
     }
+
+    /// File name suffix of the subCache file
+    ///
+    /// e.g. ".01", ".02"
+    public var fileSuffix: String {
+        "." + String(format: "%02d", index)
+    }
 }
 
 public struct DyldSubCacheEntryGeneral: LayoutWrapper {
     public typealias Layout = dyld_subcache_entry
 
     public var layout: Layout
+    public let index: Int
 }
 
 extension DyldSubCacheEntryGeneral {

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -11,10 +11,11 @@ import XCTest
 
 final class DyldCachePrintTests: XCTestCase {
     private var cache: DyldCache!
+    private var cache1: DyldCache!
 
     override func setUp() {
         print("----------------------------------------------------")
-        let arch = "x86_64h"
+        let arch = "arm64e"
         let path = "/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_\(arch)"
 //        let path = "/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_\(arch).01"
 //        let path = "/System/Volumes/Preboot/Cryptexes/OS/System/DriverKit/System/Library/dyld/dyld_shared_cache_\(arch)"
@@ -22,6 +23,10 @@ final class DyldCachePrintTests: XCTestCase {
         let url = URL(fileURLWithPath: path)
 
         self.cache = try! DyldCache(url: url)
+        self.cache1 = try! DyldCache(
+            subcacheUrl: URL(fileURLWithPath: path + ".01"),
+            mainCacheHeader: cache.header
+        )
     }
 
     func testHeader() throws {
@@ -153,6 +158,7 @@ final class DyldCachePrintTests: XCTestCase {
     }
 
     func testDylibIndices() {
+        let cache = self.cache1!
         let indices = cache.dylibIndices
             .sorted(by: { lhs, rhs in
                 lhs.index < rhs.index
@@ -163,6 +169,7 @@ final class DyldCachePrintTests: XCTestCase {
     }
 
     func testProgramOffsets() {
+        let cache = self.cache1!
         let programOffsets = cache.programOffsets
         for programOffset in programOffsets {
             print(programOffset.offset, programOffset.name)
@@ -170,6 +177,7 @@ final class DyldCachePrintTests: XCTestCase {
     }
 
     func testProgramPreBuildLoaderSet() {
+        let cache = self.cache1!
         let programOffsets = cache.programOffsets
         for programOffset in programOffsets {
             guard !programOffset.name.starts(with: "/cdhash") else {
@@ -187,6 +195,7 @@ final class DyldCachePrintTests: XCTestCase {
     }
 
     func testDylibsPreBuildLoaderSet() {
+        let cache = self.cache1!
         guard let loaderSet = cache.dylibsPrebuiltLoaderSet else {
             return
         }

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -101,13 +101,11 @@ final class DyldCachePrintTests: XCTestCase {
             print("----")
             print("UUID:", subCache.uuid)
             print("VM Offset:", String(subCache.cacheVMOffset, radix: 16))
-            if let fileSuffix = subCache.fileSuffix {
-                print("File Suffix:", fileSuffix)
-                print(
-                    "Path:",
-                    cache.url.path + fileSuffix
-                )
-            }
+            print("File Suffix:", subCache.fileSuffix)
+            print(
+                "Path:",
+                cache.url.path + subCache.fileSuffix
+            )
         }
     }
 


### PR DESCRIPTION
A dyld cache may be split into several files and is obtained as a sub subcache of the main cache.
(Retrieval of the sub cache model is already implemented and can be obtained from the `subCaches` property.)

There were cases where some properties in the dyld cache header existed only in the main cache and the file offset indicated by the property existed in the sub cache.

Fixes have been made to ensure correct loading.

