### PR TITLE
Resolve rebase / bind

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -313,11 +313,31 @@ extension DyldCache {
 
 extension DyldCache {
     public func fileOffset(of address: UInt64) -> UInt64? {
+        guard let mapping = mappingInfo(for: address) else {
+            return nil
+        }
+        return address - mapping.address + mapping.fileOffset
+    }
+
+    public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
         guard let mappings = self.mappingInfos else { return nil }
         for mapping in mappings {
             if mapping.address <= address,
                address < mapping.address + mapping.size {
-                return address - mapping.address + mapping.fileOffset
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    public func mappingAndSlideInfo(
+        for address: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = self.mappingAndSlideInfos else { return nil }
+        for mapping in mappings {
+            if mapping.address <= address,
+               address < mapping.address + mapping.size {
+                return mapping
             }
         }
         return nil

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -379,6 +379,7 @@ extension DyldCache {
 }
 
 extension DyldCache {
+    // https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MetadataVisitor.cpp#L262
     public func resolveRebase(at offset: UInt64) -> UInt64? {
         guard let mappingInfos,
               let unslidLoadAddress = mappingInfos.first?.address else {

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -319,6 +319,14 @@ extension DyldCache {
         return address - mapping.address + mapping.fileOffset
     }
 
+    public func address(of fileOffset: UInt64) -> UInt64? {
+        guard let mapping = mappingInfo(forFileOffset: fileOffset) else {
+            return nil
+        }
+        return fileOffset - mapping.fileOffset + mapping.address
+    }
+
+
     public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
         guard let mappings = self.mappingInfos else { return nil }
         for mapping in mappings {

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -377,3 +377,80 @@ extension DyldCache {
         return nil
     }
 }
+
+extension DyldCache {
+    func resolveRebase(at offset: UInt64) -> UInt64? {
+        guard let mappingInfos,
+              let unslidLoadAddress = mappingInfos.first?.address else {
+            return nil
+        }
+        guard let mapping = mappingAndSlideInfo(forFileOffset: offset) else {
+            return nil
+        }
+        guard let slideInfo = mapping.slideInfo(in: self) else {
+            let version = mapping.slideInfoVersion(in: self) ?? .none
+            if version == .none {
+                if cpu.is64Bit {
+                    let value: UInt64 = fileHandle.read(offset: offset)
+                    return value
+                } else {
+                    let value: UInt32 = fileHandle.read(offset: offset)
+                    return numericCast(value)
+                }
+            } else {
+
+            }
+            return nil
+        }
+
+        let runtimeOffset: UInt64
+        let onDiskDylibChainedPointerBaseAddress: UInt64
+        switch slideInfo {
+        case .v1:
+            let value: UInt32 = fileHandle.read(offset: offset)
+            runtimeOffset = numericCast(value) - unslidLoadAddress
+            onDiskDylibChainedPointerBaseAddress = unslidLoadAddress
+
+        case let .v2(slideInfo):
+            let rawValue: UInt64 = fileHandle.read(offset: offset)
+            let deltaMask: UInt64 = 0x00FFFF0000000000
+            let valueMask: UInt64 = ~deltaMask
+            runtimeOffset = rawValue & valueMask
+            onDiskDylibChainedPointerBaseAddress = slideInfo.value_add
+
+        case .v3:
+            let rawValue: UInt64 = fileHandle.read(offset: offset)
+            let _fixup = DyldChainedFixupPointerInfo.ARM64E(rawValue: rawValue)
+            let fixup: DyldChainedFixupPointerInfo = .arm64e(_fixup)
+            let pointer: DyldChainedFixupPointer = .init(
+                offset: Int(offset),
+                fixupInfo: fixup
+            )
+            guard let _runtimeOffset = pointer.rebaseTargetRuntimeOffset(
+                preferedLoadAddress: unslidLoadAddress
+            ) else { return nil }
+            runtimeOffset = _runtimeOffset
+            onDiskDylibChainedPointerBaseAddress = unslidLoadAddress
+
+        case let .v4(slideInfo):
+            let rawValue: UInt32 = fileHandle.read(offset: offset)
+            let deltaMask: UInt64 = 0x00000000C0000000
+            let valueMask: UInt64 = ~deltaMask
+            runtimeOffset = numericCast(rawValue) & valueMask
+            onDiskDylibChainedPointerBaseAddress = slideInfo.value_add
+
+        case let .v5(slideInfo):
+            let _fixup = DyldChainedFixupPointerInfo.ARM64ESharedCache(
+                rawValue: fileHandle.read(offset: offset)
+            )
+            let fixup: DyldChainedFixupPointerInfo = .arm64e_shared_cache(_fixup)
+            guard let rebase = fixup.rebase else {
+                return nil
+            }
+            runtimeOffset = numericCast(rebase.unpackedTarget)
+            onDiskDylibChainedPointerBaseAddress = slideInfo.value_add
+        }
+
+        return runtimeOffset + onDiskDylibChainedPointerBaseAddress
+    }
+}

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -338,6 +338,19 @@ extension DyldCache {
         return nil
     }
 
+    public func mappingInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingInfo? {
+        guard let mappings = self.mappingInfos else { return nil }
+        for mapping in mappings {
+            if mapping.fileOffset <= offset,
+               offset < mapping.fileOffset + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
+
     public func mappingAndSlideInfo(
         for address: UInt64
     ) -> DyldCacheMappingAndSlideInfo? {
@@ -345,6 +358,19 @@ extension DyldCache {
         for mapping in mappings {
             if mapping.address <= address,
                address < mapping.address + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    public func mappingAndSlideInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = self.mappingAndSlideInfos else { return nil }
+        for mapping in mappings {
+            if mapping.fileOffset <= offset,
+               offset < mapping.fileOffset + mapping.size {
                 return mapping
             }
         }

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -379,7 +379,7 @@ extension DyldCache {
 }
 
 extension DyldCache {
-    func resolveRebase(at offset: UInt64) -> UInt64? {
+    public func resolveRebase(at offset: UInt64) -> UInt64? {
         guard let mappingInfos,
               let unslidLoadAddress = mappingInfos.first?.address else {
             return nil

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -456,6 +456,7 @@ extension MachOFile {
 }
 
 extension MachOFile {
+    // https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MetadataVisitor.cpp#L262
     public func resolveRebase(at offset: UInt64) -> UInt64? {
         if isLoadedFromDyldCache,
            let cache = try? DyldCache(url: url) {

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -456,7 +456,7 @@ extension MachOFile {
 }
 
 extension MachOFile {
-    func resolveRebase(at offset: UInt64) -> UInt64? {
+    public func resolveRebase(at offset: UInt64) -> UInt64? {
         if isLoadedFromDyldCache,
            let cache = try? DyldCache(url: url) {
             return cache.resolveRebase(at: offset)

--- a/Sources/MachOKit/Model/DyldCache/DyldCacheMappingAndSlideInfo.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldCacheMappingAndSlideInfo.swift
@@ -52,6 +52,8 @@ extension DyldCacheMappingAndSlideInfo {
 
         let offset = layout.slideInfoFileOffset
         switch version {
+        case .none:
+            return nil
         case .v1:
             let layout: DyldCacheSlideInfo1.Layout = cache.fileHandle.read(
                 offset: offset

--- a/Sources/MachOKit/Model/DyldCache/SlideInfo/DyldCacheSlideInfo.swift
+++ b/Sources/MachOKit/Model/DyldCache/SlideInfo/DyldCacheSlideInfo.swift
@@ -19,6 +19,7 @@ public enum DyldCacheSlideInfo {
 
 extension DyldCacheSlideInfo {
     public enum Version: Int {
+        case none
         case v1 = 1, v2, v3, v4, v5
     }
 }

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointer.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointer.swift
@@ -12,3 +12,55 @@ public struct DyldChainedFixupPointer {
     public let offset: Int
     public let fixupInfo: DyldChainedFixupPointerInfo
 }
+
+extension DyldChainedFixupPointer {
+    // https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MachOLayout.cpp#L2087
+    func rebaseTargetRuntimeOffset(for machO: MachOFile) -> UInt64? {
+        guard let rebase = fixupInfo.rebase else {
+            return nil
+        }
+
+        let preferedLoadAddress: UInt64
+        if let text64 = machO.loadCommands.text64 {
+            preferedLoadAddress = text64.vmaddr
+        } else if let text = machO.loadCommands.text {
+            preferedLoadAddress = numericCast(text.vmaddr)
+        } else {
+            return nil
+        }
+
+        let format = fixupInfo.pointerFormat
+        switch format {
+        case .arm64e: fallthrough
+        case .arm64e_userland: fallthrough
+        case .arm64e_userland24: fallthrough
+        case .arm64e_kernel: fallthrough
+        case .arm64e_firmware:
+            if rebase.isAuth {
+                return numericCast(rebase.target)
+            } else {
+                var unpacked = rebase.unpackedTarget
+                if [.arm64e, .arm64e_firmware].contains(format) {
+                    unpacked -= preferedLoadAddress
+                }
+                return unpacked
+            }
+        case ._64: fallthrough
+        case ._64_offset:
+            var unpacked = rebase.unpackedTarget
+            if format == ._64 {
+                unpacked -= preferedLoadAddress
+            }
+            return unpacked
+        case ._64_kernel_cache: fallthrough
+        case .x86_64_kernel_cache:
+            return numericCast(rebase.target)
+        case ._32:
+            return numericCast(rebase.target) - preferedLoadAddress
+        case ._32_firmware:
+            return numericCast(rebase.target) - preferedLoadAddress
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointer.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointer.swift
@@ -15,17 +15,10 @@ public struct DyldChainedFixupPointer {
 
 extension DyldChainedFixupPointer {
     // https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MachOLayout.cpp#L2087
-    func rebaseTargetRuntimeOffset(for machO: MachOFile) -> UInt64? {
+    public func rebaseTargetRuntimeOffset(
+        preferedLoadAddress: UInt64
+    ) -> UInt64? {
         guard let rebase = fixupInfo.rebase else {
-            return nil
-        }
-
-        let preferedLoadAddress: UInt64
-        if let text64 = machO.loadCommands.text64 {
-            preferedLoadAddress = text64.vmaddr
-        } else if let text = machO.loadCommands.text {
-            preferedLoadAddress = numericCast(text.vmaddr)
-        } else {
             return nil
         }
 
@@ -63,11 +56,25 @@ extension DyldChainedFixupPointer {
             return nil
         }
     }
+
+    public func rebaseTargetRuntimeOffset(for machO: MachOFile) -> UInt64? {
+        let preferedLoadAddress: UInt64
+        if let text64 = machO.loadCommands.text64 {
+            preferedLoadAddress = text64.vmaddr
+        } else if let text = machO.loadCommands.text {
+            preferedLoadAddress = numericCast(text.vmaddr)
+        } else {
+            return nil
+        }
+        return rebaseTargetRuntimeOffset(
+            preferedLoadAddress: preferedLoadAddress
+        )
+    }
 }
 
 extension DyldChainedFixupPointer {
     // https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MachOLayout.cpp#L2139
-    func bindOrdinalAndAddend(
+    public func bindOrdinalAndAddend(
         for machO: MachOFile
     ) -> (ordinal: Int, addend: UInt64)? {
         guard let bind = fixupInfo.bind else {

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
@@ -402,6 +402,15 @@ public struct DyldChainedPtrArm64eBind: DyldChainedPointerContentBind {
     public var addend: UInt64 {
         numericCast(layout.addend)
     }
+
+    public var signExtendedAddend: UInt64 {
+        let addend19 = layout.addend
+        if (addend19 & 0x40000) != 0 {
+            return addend19 | 0xFFFFFFFFFFFC0000
+        } else {
+            return addend19
+        }
+    }
 }
 
 public struct DyldChainedPtrArm64eAuthRebase: DyldChainedPointerContentRebase {
@@ -474,6 +483,14 @@ public struct DyldChainedPtr64Bind: DyldChainedPointerContentBind {
     public var addend: UInt64 {
         numericCast(layout.addend)
     }
+
+    public var signExtendedAddend: UInt64 {
+        let addend27 = layout.addend;
+        let top8Bits = addend27 & 0x00007F80000
+        let bottom19Bits = addend27 & 0x0000007FFFF
+        let newValue = (top8Bits << 13) | (((bottom19Bits << 37) >> 37) & 0x00FFFFFFFFFFFFFF)
+        return newValue
+    }
 }
 
 public struct DyldChainedPtrArm64eBind24: DyldChainedPointerContentBind {
@@ -490,6 +507,15 @@ public struct DyldChainedPtrArm64eBind24: DyldChainedPointerContentBind {
 
     public var addend: UInt64 {
         numericCast(layout.addend)
+    }
+
+    public var signExtendedAddend: UInt64 {
+        let addend19 = layout.addend
+        if (addend19 & 0x40000) != 0 {
+            return addend19 | 0xFFFFFFFFFFFC0000
+        } else {
+            return addend19
+        }
     }
 }
 

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
@@ -349,11 +349,21 @@ extension DyldChainedFixupPointerInfo {
 public protocol DyldChainedPointerContentRebase: LayoutWrapper {
     var target: Int { get }
     var next: Int { get }
+    var isAuth: Bool { get }
+}
+
+extension DyldChainedPointerContentRebase {
+    public var isAuth: Bool { false }
 }
 
 public protocol DyldChainedPointerContentBind: LayoutWrapper {
     var ordinal: Int { get }
     var next: Int { get }
+    var isAuth: Bool { get }
+}
+
+extension DyldChainedPointerContentBind {
+    public var isAuth: Bool { false }
 }
 
 public struct DyldChainedPtrArm64eRebase: DyldChainedPointerContentRebase {
@@ -394,6 +404,8 @@ public struct DyldChainedPtrArm64eAuthRebase: DyldChainedPointerContentRebase {
         numericCast(layout.next)
     }
 
+    public var isAuth: Bool { true }
+
     public var keyName: String {
         ["IA", "IB", "DA", "DB"][Int(layout.key)]
     }
@@ -410,6 +422,8 @@ public struct DyldChainedPtrArm64eAuthBind: DyldChainedPointerContentBind {
     public var next: Int {
         numericCast(layout.next)
     }
+
+    public var isAuth: Bool { true }
 
     public var keyName: String {
         ["IA", "IB", "DA", "DB"][Int(layout.key)]
@@ -467,6 +481,8 @@ public struct DyldChainedPtrArm64eAuthBind24: DyldChainedPointerContentBind {
         numericCast(layout.next)
     }
 
+    public var isAuth: Bool { true }
+
     public var keyName: String {
         ["IA", "IB", "DA", "DB"][Int(layout.key)]
     }
@@ -483,6 +499,8 @@ public struct DyldChainedPtr64KernelCacheRebase: DyldChainedPointerContentRebase
     public var next: Int {
         numericCast(layout.next)
     }
+
+    public var isAuth: Bool { layout.isAuth != 0 }
 
     public var keyName: String {
         ["IA", "IB", "DA", "DB"][Int(layout.key)]
@@ -565,6 +583,8 @@ public struct DyldChainedPtrArm64eSharedCacheAuthRebase: DyldChainedPointerConte
     public var next: Int {
         numericCast(layout.next)
     }
+
+    public var isAuth: Bool { true }
 
     public var keyName: String {
         ["IA", "DA"][Int(layout.keyIsData)]

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
@@ -362,11 +362,13 @@ public protocol DyldChainedPointerContentBind: LayoutWrapper {
     var ordinal: Int { get }
     var next: Int { get }
     var addend: UInt64 { get }
+    var signExtendedAddend: UInt64 { get }
     var isAuth: Bool { get }
 }
 
 extension DyldChainedPointerContentBind {
     public var addend: UInt64 { 0 }
+    public var signExtendedAddend: UInt64 { addend }
     public var isAuth: Bool { false }
 }
 

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
@@ -361,10 +361,12 @@ extension DyldChainedPointerContentRebase {
 public protocol DyldChainedPointerContentBind: LayoutWrapper {
     var ordinal: Int { get }
     var next: Int { get }
+    var addend: UInt64 { get }
     var isAuth: Bool { get }
 }
 
 extension DyldChainedPointerContentBind {
+    public var addend: UInt64 { 0 }
     public var isAuth: Bool { false }
 }
 
@@ -395,6 +397,10 @@ public struct DyldChainedPtrArm64eBind: DyldChainedPointerContentBind {
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var addend: UInt64 {
+        numericCast(layout.addend)
     }
 }
 
@@ -464,6 +470,10 @@ public struct DyldChainedPtr64Bind: DyldChainedPointerContentBind {
     public var next: Int {
         numericCast(layout.next)
     }
+
+    public var addend: UInt64 {
+        numericCast(layout.addend)
+    }
 }
 
 public struct DyldChainedPtrArm64eBind24: DyldChainedPointerContentBind {
@@ -476,6 +486,10 @@ public struct DyldChainedPtrArm64eBind24: DyldChainedPointerContentBind {
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var addend: UInt64 {
+        numericCast(layout.addend)
     }
 }
 
@@ -540,6 +554,10 @@ public struct DyldChainedPtr32Bind: DyldChainedPointerContentBind {
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var addend: UInt64 {
+        numericCast(layout.addend)
     }
 }
 

--- a/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
+++ b/Sources/MachOKit/Model/DyldChain/DyldChainedFixupPointerContent.swift
@@ -350,10 +350,12 @@ public protocol DyldChainedPointerContentRebase: LayoutWrapper {
     var target: Int { get }
     var next: Int { get }
     var isAuth: Bool { get }
+    var unpackedTarget: UInt64 { get }
 }
 
 extension DyldChainedPointerContentRebase {
     public var isAuth: Bool { false }
+    public var unpackedTarget: UInt64 { numericCast(target) }
 }
 
 public protocol DyldChainedPointerContentBind: LayoutWrapper {
@@ -376,6 +378,10 @@ public struct DyldChainedPtrArm64eRebase: DyldChainedPointerContentRebase {
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var unpackedTarget: UInt64 {
+        (layout.high8 << 56) | layout.target
     }
 }
 
@@ -440,6 +446,10 @@ public struct DyldChainedPtr64Rebase: DyldChainedPointerContentRebase {
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var unpackedTarget: UInt64 {
+        (layout.high8 << 56) | layout.target
     }
 }
 
@@ -569,6 +579,10 @@ public struct DyldChainedPtrArm64eSharedCacheRebase: DyldChainedPointerContentRe
 
     public var next: Int {
         numericCast(layout.next)
+    }
+
+    public var unpackedTarget: UInt64 {
+        (layout.high8 << 56) | layout.runtimeOffset
     }
 }
 


### PR DESCRIPTION
When retrieving information from a mach-o file, there are cases where it is necessary to resolve the rebase and then retrieve the offset.
(For example, superclass or isa of objc class)

https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/common/MetadataVisitor.cpp#L262