### PR TITLE
Support old objc optimization

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
@@ -98,10 +98,34 @@ public struct ObjCHeaderInfoRO64: LayoutWrapper {
         roOptimizaion: ObjCHeaderOptimizationRO64,
         in cache: DyldCache
     ) -> MachOFile? {
+        _machO(
+            headerInfoROOffset: objcOptimization.headerInfoROCacheOffset,
+            roOptimizaion: roOptimizaion,
+            in: cache
+        )
+    }
+
+    public func machO(
+        objcOptimization: OldObjCOptimization,
+        roOptimizaion: ObjCHeaderOptimizationRO64,
+        in cache: DyldCache
+    ) -> MachOFile? {
+        _machO(
+            headerInfoROOffset: numericCast(objcOptimization.offset) + numericCast(objcOptimization.headeropt_ro_offset),
+            roOptimizaion: roOptimizaion,
+            in: cache
+        )
+    }
+
+    private func _machO(
+        headerInfoROOffset: UInt64,
+        roOptimizaion: ObjCHeaderOptimizationRO64,
+        in cache: DyldCache
+    ) -> MachOFile? {
         let offsetFromRoHeader = roOptimizaion.layoutSize + index * numericCast(roOptimizaion.entsize)
 
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        let roOffset = objcOptimization.headerInfoROCacheOffset + sharedRegionStart
+        let roOffset = headerInfoROOffset + sharedRegionStart
         let _offset: Int = numericCast(roOffset) + offsetFromRoHeader + numericCast(layout.mhdr_offset)
         guard let offset = cache.fileOffset(
             of: numericCast(_offset)
@@ -133,10 +157,34 @@ public struct ObjCHeaderInfoRO32: LayoutWrapper {
         roOptimizaion: ObjCHeaderOptimizationRO32,
         in cache: DyldCache
     ) -> MachOFile? {
+        _machO(
+            headerInfoROOffset: objcOptimization.headerInfoROCacheOffset,
+            roOptimizaion: roOptimizaion,
+            in: cache
+        )
+    }
+
+    public func machO(
+        objcOptimization: OldObjCOptimization,
+        roOptimizaion: ObjCHeaderOptimizationRO32,
+        in cache: DyldCache
+    ) -> MachOFile? {
+        _machO(
+            headerInfoROOffset: numericCast(objcOptimization.offset) + numericCast(objcOptimization.headeropt_ro_offset),
+            roOptimizaion: roOptimizaion,
+            in: cache
+        )
+    }
+
+    private func _machO(
+        headerInfoROOffset: UInt64,
+        roOptimizaion: ObjCHeaderOptimizationRO32,
+        in cache: DyldCache
+    ) -> MachOFile? {
         let offsetFromRoHeader = roOptimizaion.layoutSize + index * numericCast(roOptimizaion.entsize)
 
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        let roOffset = objcOptimization.headerInfoROCacheOffset + sharedRegionStart
+        let roOffset = headerInfoROOffset + sharedRegionStart
         let _offset: Int = numericCast(roOffset) + offsetFromRoHeader + numericCast(layout.mhdr_offset)
         guard let offset = cache.fileOffset(
             of: numericCast(_offset)

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/OldObjCOptimization.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/OldObjCOptimization.swift
@@ -1,0 +1,98 @@
+//
+//  OldObjCOptimization.swift
+//  
+//
+//  Created by p-x9 on 2024/10/06
+//  
+//
+
+import Foundation
+import MachOKitC
+
+public struct OldObjCOptimization: LayoutWrapper {
+    public typealias Layout = objc_opt_t
+
+    public var layout: Layout
+    // offset from file starts
+    public let offset: Int
+}
+
+extension OldObjCOptimization {
+    public func headerOptimizationRW64(
+        in cache: DyldCache
+    ) -> ObjCHeaderOptimizationRW64? {
+        guard layout.headeropt_rw_offset > 0 else {
+            return nil
+        }
+        let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
+        guard let offset = cache.fileOffset(
+            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_rw_offset)
+        ) else {
+            return nil
+        }
+        let layout: ObjCHeaderOptimizationRW64.Layout =  cache.fileHandle.read(offset: offset)
+        return .init(
+            layout: layout,
+            offset: numericCast(offset)
+        )
+    }
+
+    public func headerOptimizationRW32(
+        in cache: DyldCache
+    ) -> ObjCHeaderOptimizationRW32? {
+        guard layout.headeropt_rw_offset > 0 else {
+            return nil
+        }
+        let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
+        guard let offset = cache.fileOffset(
+            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_rw_offset)
+        ) else {
+            return nil
+        }
+        let layout: ObjCHeaderOptimizationRW32.Layout =  cache.fileHandle.read(offset: offset)
+        return .init(
+            layout: layout,
+            offset: numericCast(offset)
+        )
+    }
+}
+
+extension OldObjCOptimization {
+    public func headerOptimizationRO64(
+        in cache: DyldCache
+    ) -> ObjCHeaderOptimizationRO64? {
+        guard layout.headeropt_ro_offset > 0 else {
+            return nil
+        }
+        let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
+        guard let offset = cache.fileOffset(
+            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_ro_offset)
+        ) else {
+            return nil
+        }
+        let layout: ObjCHeaderOptimizationRO64.Layout =  cache.fileHandle.read(offset: offset)
+        return .init(
+            layout: layout,
+            offset: numericCast(offset)
+        )
+    }
+
+    public func headerOptimizationRO32(
+        in cache: DyldCache
+    ) -> ObjCHeaderOptimizationRO32? {
+        guard layout.headeropt_ro_offset > 0 else {
+            return nil
+        }
+        let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
+        guard let offset = cache.fileOffset(
+            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_ro_offset)
+        ) else {
+            return nil
+        }
+        let layout: ObjCHeaderOptimizationRO32.Layout =  cache.fileHandle.read(offset: offset)
+        return .init(
+            layout: layout,
+            offset: numericCast(offset)
+        )
+    }
+}

--- a/Sources/MachOKitC/include/objc.h
+++ b/Sources/MachOKitC/include/objc.h
@@ -25,6 +25,21 @@ struct objc_optimization
     uint64_t relativeMethodSelectorBaseAddressOffset;
 };
 
+// https://github.com/apple-oss-distributions/dyld/blob/65bbeed63cec73f313b1d636e63f243964725a9d/include/objc-shared-cache.h#L93
+struct objc_opt_t {
+    uint32_t version;
+    uint32_t flags;
+    int32_t selopt_offset;
+    int32_t headeropt_ro_offset;
+    int32_t unused_clsopt_offset;
+    int32_t unused_protocolopt_offset; // This is now 0 as we've moved to the new protocolopt_offset
+    int32_t headeropt_rw_offset;
+    int32_t unused_protocolopt2_offset;
+    int32_t largeSharedCachesClassOffset;
+    int32_t largeSharedCachesProtocolOffset;
+    int64_t relativeMethodSelectorBaseAddressOffset; // Relative method list selectors are offsets from this address
+};
+
 // https://github.com/apple-oss-distributions/dyld/blob/a571176e8e00c47e95b95e3156820ebec0cbd5e6/common/OptimizerObjC.h#L656
 struct header_info_rw_64 {
     uint64_t isLoaded              : 1;


### PR DESCRIPTION
Old ObjC Optimisation exists in /usr/lib/libobjc.A.dylib in the __TEXT.__objc_opt_ro section