### PR TITLE
Fix not to use `uuid/uuid.h`

### DIFF
--- a/Sources/MachOKitC/include/dyld_cache_format.h
+++ b/Sources/MachOKitC/include/dyld_cache_format.h
@@ -28,7 +28,9 @@
 #define __DYLD_CACHE_FORMAT__
 
 #include <stdint.h>
-#include <uuid/uuid.h>
+
+//#include <uuid/uuid.h>
+typedef uint8_t uuid_t[16];
 
 //#include <mach-o/fixup-chains.h>
 #include "fixup-chains.h"


### PR DESCRIPTION
`uuid/uuid.h` is available by default in apple platfom.
On the other hand, on Ubuntu and other linux platforms, it must be installed using the following command.

```sh
apt-get uuid-dev
```

However, as there is only one point of use, it has been modified to use the `uuid_t` defined by itself using `typedef`.
