### PR TITLE
Use access level instead of `(at)_implementationOnly`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,9 @@ let package = Package(
                 "MachOKitC",
                 .product(name: "Crypto", package: "swift-crypto")
             ],
-            swiftSettings: SwiftSetting.allCases
+            swiftSettings: SwiftSetting.allCases + [
+                .enableExperimentalFeature("AccessLevelOnImport", .when(configuration: .debug))
+            ]
         ),
         .target(
             name: "MachOKitC",

--- a/Sources/MachOKit/Model/Codesign/CodeDirectory/CodeSignCodeDirectory.swift
+++ b/Sources/MachOKit/Model/Codesign/CodeDirectory/CodeSignCodeDirectory.swift
@@ -8,11 +8,13 @@
 
 import Foundation
 import MachOKitC
-//#if compiler(>=5.10)
-//private import Crypto
-//#else
+#if compiler(>=6.0)
+private import Crypto
+#elseif compiler(>=5.10) && hasFeature(AccessLevelOnImport)
+private import Crypto
+#else
 @_implementationOnly import Crypto
-//#endif
+#endif
 
 public struct CodeSignCodeDirectory: LayoutWrapper {
     public typealias Layout = CS_CodeDirectory


### PR DESCRIPTION
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md