### PR TITLE
[ObjC] Fix offset calculation in objc optimization

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -368,7 +368,13 @@ extension DyldCache {
 
         let offset = __objc_opt_ro.offset + libobjc.headerStartOffset
         let layout: OldObjCOptimization.Layout = fileHandle.read(offset: numericCast(offset))
-        return .init(layout: layout, offset: offset)
+        guard let address = address(of: numericCast(offset)) else {
+            return nil
+        }
+
+        return .init(
+            layout: layout,
+            offset: numericCast(address - mainCacheHeader.sharedRegionStart))
     }
 
     public var swiftOptimization: SwiftOptimization? {

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol ObjCHeaderInfoROProtocol {
     associatedtype HeaderOptimizationRO: ObjCHeaderOptimizationROProtocol, LayoutWrapper
-    /// offset from dyld cache starts
+    /// offset from start address of main cache
     var offset: Int { get }
     /// index of this header info
     var index: Int { get }

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
@@ -3,7 +3,7 @@
 //
 //
 //  Created by p-x9 on 2024/05/29
-//  
+//
 //
 
 import Foundation
@@ -41,13 +41,14 @@ extension ObjCOptimization {
         guard layout.headerInfoRWCacheOffset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(layout.headerInfoRWCacheOffset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(layout.headerInfoRWCacheOffset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRW64.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRW64.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -63,13 +64,14 @@ extension ObjCOptimization {
         guard layout.headerInfoRWCacheOffset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(layout.headerInfoRWCacheOffset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(layout.headerInfoRWCacheOffset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRW32.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRW32.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -129,13 +131,14 @@ extension ObjCOptimization {
         guard layout.headerInfoROCacheOffset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(layout.headerInfoROCacheOffset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(layout.headerInfoROCacheOffset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRO64.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRO64.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -148,16 +151,14 @@ extension ObjCOptimization {
     public func headerOptimizationRO32(
         in cache: DyldCache
     ) -> ObjCHeaderOptimizationRO32? {
-        guard layout.headerInfoROCacheOffset > 0 else {
-            return nil
-        }
+        let offset: UInt64 = numericCast(layout.headerInfoROCacheOffset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(layout.headerInfoROCacheOffset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRO32.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRO32.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/OldObjCOptimization.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/OldObjCOptimization.swift
@@ -13,7 +13,7 @@ public struct OldObjCOptimization: LayoutWrapper {
     public typealias Layout = objc_opt_t
 
     public var layout: Layout
-    // offset from file starts
+    /// offset from start address of main cache
     public let offset: Int
 }
 
@@ -42,13 +42,14 @@ extension OldObjCOptimization {
         guard layout.headeropt_rw_offset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(offset) + numericCast(layout.headeropt_rw_offset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_rw_offset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRW64.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRW64.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -64,13 +65,14 @@ extension OldObjCOptimization {
         guard layout.headeropt_rw_offset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(offset) + numericCast(layout.headeropt_rw_offset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_rw_offset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRW32.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRW32.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -128,13 +130,14 @@ extension OldObjCOptimization {
         guard layout.headeropt_ro_offset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(offset) + numericCast(layout.headeropt_ro_offset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_ro_offset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRO64.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRO64.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)
@@ -150,13 +153,14 @@ extension OldObjCOptimization {
         guard layout.headeropt_ro_offset > 0 else {
             return nil
         }
+        let offset: UInt64 = numericCast(offset) + numericCast(layout.headeropt_ro_offset)
         let sharedRegionStart = cache.mainCacheHeader.sharedRegionStart
-        guard let offset = cache.fileOffset(
-            of: sharedRegionStart + numericCast(offset) + numericCast(layout.headeropt_ro_offset)
+        guard let resolvedOffset = cache.fileOffset(
+            of: sharedRegionStart + offset
         ) else {
             return nil
         }
-        let layout: ObjCHeaderOptimizationRO32.Layout = cache.fileHandle.read(offset: offset)
+        let layout: ObjCHeaderOptimizationRO32.Layout = cache.fileHandle.read(offset: resolvedOffset)
         return .init(
             layout: layout,
             offset: numericCast(offset)

--- a/Sources/MachOKitC/include/objc.h
+++ b/Sources/MachOKitC/include/objc.h
@@ -78,6 +78,7 @@ struct objc_header_info_ro_t_32 {
 };
 
 // https://github.com/apple-oss-distributions/dyld/blob/a571176e8e00c47e95b95e3156820ebec0cbd5e6/common/OptimizerObjC.h#L772
+// https://github.com/apple-oss-distributions/objc4/blob/89543e2c0f67d38ca5211cea33f42c51500287d5/runtime/objc-private.h#L418
 struct objc_headeropt_ro_t_64 {
     uint32_t count;
     uint32_t entsize;

--- a/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
+++ b/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
@@ -279,6 +279,11 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
                 print(" nil")
                 continue
             }
+
+            let _info = ro.headerInfo(in: cache, for: machO)!
+            XCTAssertEqual(info.mhdr_offset, _info.mhdr_offset)
+            XCTAssertEqual(info.info_offset, _info.info_offset)
+
             let path = machO.loadCommands
                 .info(of: LoadCommand.idDylib)?
                 .dylib(cmdsStart: machO.cmdsStartPtr)

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -232,7 +232,7 @@ final class DyldCachePrintTests: XCTestCase {
     func testObjCHeaderOptimizationRW() throws {
         guard let objcOptimization = cache.objcOptimization else { return }
         let rw = objcOptimization.headerOptimizationRW64(in: cache)!
-        let rwHeaders = rw.headerInfos(in: cache)
+        let rwHeaders = rw.headerInfos(in: cache)!
         print("Count:", rw.count)
         print("EntrySize:", rw.entrySize)
         for info in rwHeaders {
@@ -243,7 +243,7 @@ final class DyldCachePrintTests: XCTestCase {
     func testObjCHeaderOptimizationRO() throws {
         guard let objcOptimization = cache.objcOptimization else { return }
         let ro = objcOptimization.headerOptimizationRO64(in: cache)!
-        let roHeaders = ro.headerInfos(in: cache)
+        let roHeaders = ro.headerInfos(in: cache)!
         print("Count:", ro.count)
         print("EntrySize:", ro.entrySize)
 
@@ -264,6 +264,11 @@ final class DyldCachePrintTests: XCTestCase {
                 print(" nil")
                 continue
             }
+
+            let _info = ro.headerInfo(in: cache, for: machO)!
+            XCTAssertEqual(info.mhdr_offset, _info.mhdr_offset)
+            XCTAssertEqual(info.info_offset, _info.info_offset)
+
             let path = machO.loadCommands
                 .info(of: LoadCommand.idDylib)?
                 .dylib(in: machO)


### PR DESCRIPTION
File and address offsets from the beginning of the main cache do not always match.