### PR TITLE
[dyld cache] Support latest and older version of prebuilt loader

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader.swift
@@ -18,11 +18,11 @@ public struct PrebuiltLoader: LayoutWrapper {
 extension PrebuiltLoader {
     // always true
     public var isPrebuilt: Bool {
-        layout.isPrebuilt != 0
+        layout.loader.isPrebuilt != 0
     }
 
     public var ref: LoaderRef {
-        .init(layout: layout.ref)
+        .init(layout: layout.loader.ref)
     }
 }
 
@@ -79,7 +79,7 @@ extension PrebuiltLoader {
 extension PrebuiltLoader {
     // [dyld implementation](https://github.com/apple-oss-distributions/dyld/blob/65bbeed63cec73f313b1d636e63f243964725a9d/dyld/Loader.h#L317)
     public var magic: String? {
-        withUnsafeBytes(of: layout.magic.bigEndian, {
+        withUnsafeBytes(of: layout.loader.magic.bigEndian, {
             let cString = $0.map({ CChar($0)} ) + [0]
             return String(
                 cString: cString,

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderProtocol.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderProtocol.swift
@@ -10,15 +10,32 @@
 import Foundation
 
 public protocol PrebuiltLoaderProtocol {
+    /// Address where this loader is located.
+    ///
+    /// Slides after loading are not included.
     var address: Int { get }
 
+    /// magic of loader starts
     var magic: String? { get }
+    ///  PrebuiltLoader vs JustInTimeLoader
     var isPrebuilt: Bool { get }
     var ref: LoaderRef { get }
 
+    /// path for target mach-o image
+    /// - Parameter cache: DyldCache to which `self` belongs
+    /// - Returns: path name
     func path(in cache: DyldCache) -> String?
+    /// loader reference list of target 's dependencies
+    /// - Parameter cache: DyldCache to which `self` belongs
+    /// - Returns: sequence of loader reference
     func dependentLoaderRefs(in cache: DyldCache) -> DataSequence<LoaderRef>?
 
+    /// path for target mach-o image
+    /// - Parameter cache: DyldCacheLoaded to which `self` belongs
+    /// - Returns: path name
     func path(in cache: DyldCacheLoaded) -> String?
+    /// loader reference list of target 's dependencies
+    /// - Parameter cache: DyldCacheLoaded to which `self` belongs
+    /// - Returns: sequence of loader reference
     func dependentLoaderRefs(in cache: DyldCacheLoaded) -> MemorySequence<LoaderRef>?
 }

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderProtocol.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  PrebuiltLoaderProtocol.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2024/11/09
+//  
+//
+
+
+import Foundation
+
+public protocol PrebuiltLoaderProtocol {
+    var address: Int { get }
+
+    var magic: String? { get }
+    var isPrebuilt: Bool { get }
+    var ref: LoaderRef { get }
+
+    func path(in cache: DyldCache) -> String?
+    func dependentLoaderRefs(in cache: DyldCache) -> DataSequence<LoaderRef>?
+
+    func path(in cache: DyldCacheLoaded) -> String?
+    func dependentLoaderRefs(in cache: DyldCacheLoaded) -> MemorySequence<LoaderRef>?
+}

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoaderSet.swift
@@ -154,3 +154,46 @@ extension PrebuiltLoaderSet {
         })
     }
 }
+
+extension PrebuiltLoaderSet {
+    public enum KnownVersion: UInt32, CaseIterable {
+        /// from dyld-940
+        case v0x041c09d6 = 0x041c09d6
+        /// from dyld-955
+        case v0xcb8ba960 = 0xcb8ba960
+        /// from dyld-1042.1
+        case v0x4d2b8647 = 0x4d2b8647
+        /// from dyld-1122.1
+        case v0xd647423f = 0xd647423f
+        /// from dyld-1160.6
+        case v0x9a661060 = 0x9a661060
+        /// from dyld-1231.3
+        case v0x173a676e = 0x173a676e
+
+        public var isLatest: Bool {
+            self == .v0x173a676e
+        }
+
+        public var isPre1165_3: Bool {
+            [
+                .v0x041c09d6,
+                .v0xcb8ba960,
+                .v0x4d2b8647,
+                .v0xd647423f,
+                .v0x9a661060
+            ].contains(self)
+        }
+    }
+
+    public var version: KnownVersion? {
+        KnownVersion(rawValue: layout.versionHash)
+    }
+
+    public var isKnownVersion: Bool {
+        version != nil
+    }
+
+    public var isLatestVersion: Bool {
+        version?.isLatest ?? false
+    }
+}

--- a/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader_Pre1165_3.swift
+++ b/Sources/MachOKit/Model/DyldCache/Loader/PrebuiltLoader_Pre1165_3.swift
@@ -1,21 +1,19 @@
 //
-//  PrebuiltLoader.swift
-//  
+//  PrebuiltLoader_Pre1165_3.swift
+//  MachOKit
 //
-//  Created by p-x9 on 2024/07/09
+//  Created by p-x9 on 2024/11/09
 //  
 //
 
-import Foundation
-
-public struct PrebuiltLoader: LayoutWrapper, PrebuiltLoaderProtocol {
-    public typealias Layout = prebuilt_loader
+public struct PrebuiltLoader_Pre1165_3: LayoutWrapper, PrebuiltLoaderProtocol {
+    public typealias Layout = prebuilt_loader_pre1165_3
 
     public var layout: Layout
     public var address: Int
 }
 
-extension PrebuiltLoader {
+extension PrebuiltLoader_Pre1165_3 {
     // always true
     public var isPrebuilt: Bool {
         layout.loader.isPrebuilt != 0
@@ -26,7 +24,7 @@ extension PrebuiltLoader {
     }
 }
 
-extension PrebuiltLoader {
+extension PrebuiltLoader_Pre1165_3 {
     public func path(in cache: DyldCache) -> String? {
         guard let offset = cache.fileOffset(
             of: numericCast(address) + numericCast(layout.pathOffset)
@@ -48,7 +46,7 @@ extension PrebuiltLoader {
     }
 }
 
-extension PrebuiltLoader {
+extension PrebuiltLoader_Pre1165_3 {
     public func path(in cache: DyldCacheLoaded) -> String? {
         // swiftlint:disable:previous unused_parameter
         guard let baseAddress = UnsafeRawPointer(bitPattern: address) else {
@@ -76,7 +74,7 @@ extension PrebuiltLoader {
     }
 }
 
-extension PrebuiltLoader {
+extension PrebuiltLoader_Pre1165_3 {
     // [dyld implementation](https://github.com/apple-oss-distributions/dyld/blob/65bbeed63cec73f313b1d636e63f243964725a9d/dyld/Loader.h#L317)
     public var magic: String? {
         withUnsafeBytes(of: layout.loader.magic.bigEndian, {

--- a/Sources/MachOKitC/include/dyld_cache_loader.h
+++ b/Sources/MachOKitC/include/dyld_cache_loader.h
@@ -55,7 +55,7 @@ struct section_locations {
     uint64_t sizes[21];
 };
 
-struct loader_pre1160_6 {
+struct loader_pre1165_3 {
     const uint32_t      magic;                    // kMagic
     const uint16_t      isPrebuilt         :  1,  // PrebuiltLoader vs JustInTimeLoader
                         dylibInDyldCache   :  1,
@@ -94,8 +94,8 @@ struct loader {
     uint32_t            unused;
 };
 
-struct prebuilt_loader_pre1160_6 {
-    struct loader_pre1160_6   loader;
+struct prebuilt_loader_pre1165_3 {
+    struct loader_pre1165_3   loader;
 
     uint16_t            pathOffset;
     uint16_t            dependentLoaderRefsArrayOffset; // offset to array of LoaderRef

--- a/Sources/MachOKitC/include/dyld_cache_loader.h
+++ b/Sources/MachOKitC/include/dyld_cache_loader.h
@@ -27,7 +27,8 @@ struct prebuilt_loader_set {
     uint32_t    objcProtocolHashTableOffset;
     uint32_t    reserved;
     uint64_t    objcProtocolClassCacheOffset;
-    // Swift prebuilt data
+
+    // Swift prebuilt data (from dyld-1160.6)
     uint32_t    swiftTypeConformanceTableOffset;
     uint32_t    swiftMetadataConformanceTableOffset;
     uint32_t    swiftForeignTypeConformanceTableOffset;
@@ -54,9 +55,23 @@ struct section_locations {
     uint64_t sizes[21];
 };
 
-// ref: https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/dyld/PrebuiltLoader.h#L83
-struct prebuilt_loader {
-    // Loader
+struct loader_pre1160_6 {
+    const uint32_t      magic;                    // kMagic
+    const uint16_t      isPrebuilt         :  1,  // PrebuiltLoader vs JustInTimeLoader
+                        dylibInDyldCache   :  1,
+                        hasObjC            :  1,
+                        mayHavePlusLoad    :  1,
+                        hasReadOnlyData    :  1,  // __DATA_CONST
+                        neverUnload        :  1,  // part of launch or has non-unloadable data (e.g. objc, tlv)
+                        leaveMapped        :  1,  // RTLD_NODELETE
+                        hasReadOnlyObjC    :  1,  // Has __DATA_CONST,__objc_selrefs section // from 1042.1
+                        pre2022Binary      :  1,
+                        isPremapped        :  1,  // mapped by exclave core // from dyld-1122.1
+                        padding            :  6;
+    struct loader_ref   ref;
+};
+
+struct loader {
     const uint32_t      magic;                    // kMagic
     const uint16_t      isPrebuilt         :  1,  // PrebuiltLoader vs JustInTimeLoader
                         dylibInDyldCache   :  1,
@@ -68,8 +83,61 @@ struct prebuilt_loader {
                         hasReadOnlyObjC    :  1,  // Has __DATA_CONST,__objc_selrefs section
                         pre2022Binary      :  1,
                         isPremapped        :  1,  // mapped by exclave core
-                        padding            :  6;
-    struct loader_ref ref;
+                        hasUUIDLoadCommand :  1,
+                        hasWeakDefs        :  1,
+                        hasTLVs            :  1,
+                        belowLibSystem     :  1,
+                        padding            :  2;
+    struct loader_ref   ref;
+    uuid_t              uuid;
+    uint32_t            cpusubtype;
+    uint32_t            unused;
+};
+
+struct prebuilt_loader_pre1160_6 {
+    struct loader_pre1160_6   loader;
+
+    uint16_t            pathOffset;
+    uint16_t            dependentLoaderRefsArrayOffset; // offset to array of LoaderRef
+    uint16_t            dependentKindArrayOffset;       // zero if all deps normal
+    uint16_t            fixupsLoadCommandOffset;
+
+    uint16_t            altPathOffset;                  // if install_name does not match real path
+    uint16_t            fileValidationOffset;           // zero or offset to FileValidationInfo
+
+    uint16_t            hasInitializers  :  1,
+                        isOverridable    :  1,          // if in dyld cache, can roots override it
+                        supportsCatalyst :  1,          // if false, this cannot be used in catalyst process
+                        overridesCache   :  1,          // catalyst side of unzippered twin
+                        regionsCount     : 12;
+    uint16_t            regionsOffset;                  // offset to Region array
+
+    uint16_t            depCount;
+    uint16_t            bindTargetRefsOffset;
+    uint32_t            bindTargetRefsCount;            // bind targets can be large, so it is last
+    // After this point, all offsets in to the PrebuiltLoader need to be 32-bits as the bind targets can be large
+
+    uint32_t            objcBinaryInfoOffset;           // zero or offset to ObjCBinaryInfo
+    uint16_t            indexOfTwin;                    // if in dyld cache and part of unzippered twin, then index of the other twin
+    uint16_t            reserved1;
+
+    uint64_t            exportsTrieLoaderOffset;
+    uint32_t            exportsTrieLoaderSize;
+    uint32_t            vmSpace;
+
+    struct code_signature_in_file codeSignature;
+
+    uint32_t            patchTableOffset;
+
+    uint32_t            overrideBindTargetRefsOffset;
+    uint32_t            overrideBindTargetRefsCount;
+
+    struct section_locations    sectionLocations; // from dyld-1160.6
+};
+
+// ref: https://github.com/apple-oss-distributions/dyld/blob/d552c40cd1de105f0ec95008e0e0c0972de43456/dyld/PrebuiltLoader.h#L83
+struct prebuilt_loader {
+    struct loader       loader;
 
     // Main
     uint16_t            pathOffset;

--- a/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
+++ b/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
@@ -3,7 +3,7 @@
 //
 //
 //  Created by p-x9 on 2024/10/10
-//  
+//
 //
 
 import XCTest
@@ -156,7 +156,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
     }
 
     func testDylibIndices() {
-        let cache = cache1!
+        let cache = cache!
         let indices = cache.dylibIndices
             .sorted(by: { lhs, rhs in
                 lhs.index < rhs.index
@@ -167,7 +167,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
     }
 
     func testProgramOffsets() {
-        let cache = cache1!
+        let cache = cache!
         let programOffsets = cache.programOffsets
         for programOffset in programOffsets {
             print(programOffset.offset, programOffset.name)
@@ -175,7 +175,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
     }
 
     func testProgramPreBuildLoaderSet() {
-        let cache = self.cache1!
+        let cache = self.cache!
         let programOffsets = cache.programOffsets
         for programOffset in programOffsets {
             guard !programOffset.name.starts(with: "/cdhash") else {
@@ -187,6 +187,9 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
             print("Name:", programOffset.name)
             print("Loaders:")
             for loader in loaderSet.loaders(in: cache)! {
+                print("  \(loader.path(in: cache) ?? "unknown")")
+            }
+            for loader in loaderSet.loaders_pre1165_3(in: cache) ?? [] {
                 print("  \(loader.path(in: cache) ?? "unknown")")
             }
             let dyldCacheUUID = loaderSet.dyldCacheUUID(in: cache)
@@ -204,6 +207,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
         guard let loaderSet = cache.dylibsPrebuiltLoaderSet else {
             return
         }
+        XCTAssertNotNil(loaderSet.version)
         print("Loaders:")
         for loader in loaderSet.loaders(in: cache) ?? [] {
             print("  \(loader.path(in: cache) ?? "unknown")")

--- a/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
+++ b/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
@@ -200,12 +200,15 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
     }
 
     func testDylibsPreBuildLoaderSet() {
-        let cache = self.cache1!
+        let cache = self.cache!
         guard let loaderSet = cache.dylibsPrebuiltLoaderSet else {
             return
         }
         print("Loaders:")
-        for loader in loaderSet.loaders(in: cache)! {
+        for loader in loaderSet.loaders(in: cache) ?? [] {
+            print("  \(loader.path(in: cache) ?? "unknown")")
+        }
+        for loader in loaderSet.loaders_pre1165_3(in: cache) ?? [] {
             print("  \(loader.path(in: cache) ?? "unknown")")
         }
     }

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -196,6 +196,9 @@ final class DyldCachePrintTests: XCTestCase {
             for loader in loaderSet.loaders(in: cache)! {
                 print("  \(loader.path(in: cache) ?? "unknown")")
             }
+            for loader in loaderSet.loaders_pre1165_3(in: cache) ?? [] {
+                print("  \(loader.path(in: cache) ?? "unknown")")
+            }
             let dyldCacheUUID = loaderSet.dyldCacheUUID(in: cache)
             print("dyldCacheUUID:", dyldCacheUUID?.uuidString ?? "None")
             let mustBeMissingPaths = loaderSet.mustBeMissingPaths(in: cache) ?? []
@@ -211,6 +214,7 @@ final class DyldCachePrintTests: XCTestCase {
         guard let loaderSet = cache.dylibsPrebuiltLoaderSet else {
             return
         }
+        XCTAssertNotNil(loaderSet.version)
         print("Loaders:")
         for loader in loaderSet.loaders(in: cache) ?? [] {
             print("  \(loader.path(in: cache) ?? "unknown")")

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -212,7 +212,10 @@ final class DyldCachePrintTests: XCTestCase {
             return
         }
         print("Loaders:")
-        for loader in loaderSet.loaders(in: cache)! {
+        for loader in loaderSet.loaders(in: cache) ?? [] {
+            print("  \(loader.path(in: cache) ?? "unknown")")
+        }
+        for loader in loaderSet.loaders_pre1165_3(in: cache) ?? [] {
             print("  \(loader.path(in: cache) ?? "unknown")")
         }
     }


### PR DESCRIPTION
| dyld version | macOS  | Version Hash    |
|--------------|--------|---------------------|
| dyld-940     | 12.0.1 | 68946390 (941.2.1)     |
| dyld-955     | 12.3.0 | 3414927712 (1041.6.0) |
| dyld-1042.1  | 13.2   | 1294698055 (1042.1.0) |
| dyld-1066    | 13.5   | 1294698055 (1066.8.0) |
| dyld-1122.1  | 14.1   | 3594994239 (1122.1.2) |
| dyld-1160.6  | 14.4   | 2590380128 (1160.6.0) |
| dyld-1165.3  | 14.6   | 2590380128 (1165.3.0) |
| dyld-1231.3  | 15.0   | 389703534 (1231.3.0) |