### PR TITLE
Fix to find multiple symbols with the same name/offset

### DIFF
--- a/Sources/MachOKit/Extension/Sequence+.swift
+++ b/Sources/MachOKit/Extension/Sequence+.swift
@@ -279,22 +279,32 @@ extension Sequence where Element == MachOFile.Symbol {
     func named(
         _ name: String,
         mangled: Bool = true
-    ) -> Element? {
+    ) -> [Element] {
         guard let nameC = name.cString(using: .utf8) else {
-            return nil
+            return []
         }
+        var results: [Element] = []
         for symbol in self {
             if strcmp(nameC, symbol.name) == 0 ||
                 symbol.name.withCString({ strcmp(nameC, $0 + 1) == 0 }) {
-                return symbol
+                results.append(symbol)
             } else if !mangled {
                 let demangled = stdlib_demangleName(symbol.name)
                 if strcmp(nameC, demangled) == 0 {
-                    return symbol
+                    results.append(symbol)
                 }
             }
         }
-        return nil
+        return results
+    }
+
+    @available(*, deprecated, renamed: "named(_:mangled:)", message: "Please use a new function that returns as an array")
+    @_disfavoredOverload
+    func named(
+        _ name: String,
+        mangled: Bool = true
+    ) -> Element? {
+        named(name, mangled: mangled).first
     }
 }
 
@@ -303,21 +313,31 @@ extension Sequence where Element == MachOImage.Symbol {
     func named(
         _ name: String,
         mangled: Bool = true
-    ) -> Element? {
+    ) -> [Element] {
         guard let nameC = name.cString(using: .utf8) else {
-            return nil
+            return []
         }
+        var results: [Element] = []
         for symbol in self {
             if strcmp(nameC, symbol.nameC) == 0 || strcmp(nameC, symbol.nameC + 1) == 0 {
-                return symbol
+                results.append(symbol)
             } else if !mangled {
                 let demangled = stdlib_demangleName(symbol.nameC)
                 if strcmp(nameC, demangled) == 0 {
-                    return symbol
+                    results.append(symbol)
                 }
             }
         }
-        return nil
+        return results
+    }
+
+    @available(*, deprecated, renamed: "named(_:mangled:)", message: "Please use a new function that returns as an array")
+    @_disfavoredOverload
+    func named(
+        _ name: String,
+        mangled: Bool = true
+    ) -> Element? {
+        named(name, mangled: mangled).first
     }
 }
 

--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -134,19 +134,25 @@ extension MachOImage {
     /// - Parameters:
     ///   - name: symbol name to search
     ///   - mangled: A boolean value that indicates whether the specified symbol name is mangled or not.
+    ///   - isGlobalOnly: If true, search only global symbols.
     /// - Returns: Sequence of matched symbols and machO images.
-    @available(*, deprecated, renamed: "symbols(named:mangled:)", message: "Please use a new function that returns as an symbol array")
-    @_disfavoredOverload
     public static func symbols(
         named name: String,
-        mangled: Bool = true
+        mangled: Bool = true,
+        isGlobalOnly: Bool = false
     ) -> AnySequence<(MachOImage, Symbol)> {
         AnySequence(
-            symbols(named: name, mangled: mangled)
-                .flatMap { machO, symbols in
-                    symbols.map {
-                        (machO, $0)
+            images
+                .lazy
+                .compactMap {
+                    guard let symbol = $0.symbol(
+                        named: name,
+                        mangled: mangled,
+                        isGlobalOnly: isGlobalOnly
+                    ) else {
+                        return nil
                     }
+                    return ($0, symbol)
                 }
         )
     }

--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -43,37 +43,7 @@ extension MachOImage {
                 return (image, symbol)
             }
         }
-
-        var closestImage: MachOImage?
-        var leastDistance: Int?
-        for image in images {
-            let address = Int(bitPattern: address)
-            guard let distance = leastDistance else {
-                if let range = image.addressRange {
-                    closestImage = image
-                    leastDistance = min(
-                        abs(range.lowerBound - address),
-                        abs(range.upperBound - address)
-                    )
-                }
-                continue
-            }
-
-            guard let range = image.addressRange else {
-                continue
-            }
-
-            let newDistance = min(
-                abs(range.lowerBound - address),
-                abs(range.upperBound - address)
-            )
-            if newDistance < distance {
-                leastDistance = newDistance
-                closestImage = image
-            }
-        }
-
-        guard let closestImage,
+        guard let closestImage = closestImage(at: address),
               let symbol = closestImage.closestSymbol(
                 at: address,
                 isGlobalOnly: isGlobalOnly
@@ -81,6 +51,39 @@ extension MachOImage {
             return nil
         }
         return (closestImage, symbol)
+    }
+
+    /// Obtains the symbols closest to the specified address.
+    ///
+    /// Finds the symbol closest to the specified address among all loaded machO images.
+    /// - Parameters:
+    ///   - address: Addresses to search
+    ///   - isGlobalOnly: A Boolean value that indicates whether to look for global symbols only (or to look for local symbols as well)
+    /// - Returns: The closest symbols and the machO image to which it belongs.
+    public static func closestSymbols(
+        at address: UnsafeRawPointer,
+        isGlobalOnly: Bool = false
+    ) -> (MachOImage, [Symbol])? {
+        for image in images where image.contains(address) {
+            let symbols = image.closestSymbols(
+                at: address,
+                isGlobalOnly: isGlobalOnly
+            )
+            if !symbols.isEmpty {
+                return (image, symbols)
+            }
+        }
+        guard let closestImage = closestImage(at: address) else {
+            return nil
+        }
+        let symbols = closestImage.closestSymbols(
+            at: address,
+            isGlobalOnly: isGlobalOnly
+        )
+        guard !symbols.isEmpty else {
+            return nil
+        }
+        return (closestImage, symbols)
     }
 
     /// Obtains the symbol that exist at the specified address.
@@ -146,6 +149,42 @@ extension MachOImage {
                     }
                 }
         )
+    }
+}
+
+fileprivate extension MachOImage {
+    static func closestImage(
+        at address: UnsafeRawPointer
+    ) -> MachOImage? {
+        var closestImage: MachOImage?
+        var leastDistance: Int?
+        for image in images {
+            let address = Int(bitPattern: address)
+            guard let distance = leastDistance else {
+                if let range = image.addressRange {
+                    closestImage = image
+                    leastDistance = min(
+                        abs(range.lowerBound - address),
+                        abs(range.upperBound - address)
+                    )
+                }
+                continue
+            }
+
+            guard let range = image.addressRange else {
+                continue
+            }
+
+            let newDistance = min(
+                abs(range.lowerBound - address),
+                abs(range.upperBound - address)
+            )
+            if newDistance < distance {
+                leastDistance = newDistance
+                closestImage = image
+            }
+        }
+        return closestImage
     }
 }
 

--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -113,15 +113,37 @@ extension MachOImage {
     public static func symbols(
         named name: String,
         mangled: Bool = true
-    ) -> AnySequence<(MachOImage, Symbol)> {
+    ) -> AnySequence<(MachOImage, [Symbol])> {
         AnySequence(
             images
                 .lazy
                 .compactMap {
-                    guard let symbol = $0.symbol(named: name, mangled: mangled) else {
+                    let symbols = $0.symbols(named: name, mangled: mangled)
+                    guard !symbols.isEmpty else {
                         return nil
                     }
-                    return ($0, symbol)
+                    return ($0, symbols)
+                }
+        )
+    }
+
+    /// Obtains symbols matching the specified name.
+    /// - Parameters:
+    ///   - name: symbol name to search
+    ///   - mangled: A boolean value that indicates whether the specified symbol name is mangled or not.
+    /// - Returns: Sequence of matched symbols and machO images.
+    @available(*, deprecated, renamed: "symbols(named:mangled:)", message: "Please use a new function that returns as an symbol array")
+    @_disfavoredOverload
+    public static func symbols(
+        named name: String,
+        mangled: Bool = true
+    ) -> AnySequence<(MachOImage, Symbol)> {
+        AnySequence(
+            symbols(named: name, mangled: mangled)
+                .flatMap { machO, symbols in
+                    symbols.map {
+                        (machO, $0)
+                    }
                 }
         )
     }

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -495,10 +495,31 @@ extension MachOImage {
             isGlobalOnly: isGlobalOnly
         )
     }
+    /// Find the symbols closest to the address at the specified offset.
+    ///
+    /// Different from ``closestSymbol(at:inSection:isGlobalOnly:)`` multiple symbols with the same offset may be found.
+    ///
+    /// - Parameters:
+    ///   - address: Address to find closest symbol.
+    ///   - sectionNumber: Section number to be searched.
+    ///   - isGlobalOnly: If true, search only global symbols.
+    /// - Returns: Closest symbols.
+    func closestSymbols(
+        at address: UnsafeRawPointer,
+        inSection sectionNumber: Int = 0,
+        isGlobalOnly: Bool = false
+    ) -> [Symbol] {
+        let offset = Int(bitPattern: address) - Int(bitPattern: ptr)
+        return closestSymbols(
+            at: offset,
+            inSection: sectionNumber,
+            isGlobalOnly: isGlobalOnly
+        )
+    }
 
     /// Find symbols matching the specified address.
     /// - Parameters:
-    ///   -  address: Address to find matching symbol.
+    ///   - address: Address to find matching symbol.
     ///   - isGlobalOnly: If true, search only global symbols.
     /// - Returns: Matched symbol
     public func symbol(
@@ -507,6 +528,22 @@ extension MachOImage {
     ) -> Symbol? {
         let offset = Int(bitPattern: address) - Int(bitPattern: ptr)
         return symbol(for: offset, isGlobalOnly: isGlobalOnly)
+    }
+
+    /// Find the symbols matching the specified offset.
+    ///
+    /// Different from ``symbol(for:isGlobalOnly:)`` multiple symbols with the same offset may be found.
+    ///
+    /// - Parameters:
+    ///   - address: Address to find matching symbol.
+    ///   - isGlobalOnly: If true, search only global symbols.
+    /// - Returns: Matched symbols
+    func symbols(
+        for address: UnsafeRawPointer,
+        isGlobalOnly: Bool = false
+    ) -> [Symbol] {
+        let offset = Int(bitPattern: address) - Int(bitPattern: ptr)
+        return symbols(for: offset, isGlobalOnly: isGlobalOnly)
     }
 }
 

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -373,6 +373,8 @@ extension MachORepresentable where Symbol == MachOFile.Symbol {
         return []
     }
 
+    @available(*, deprecated, renamed: "symbols(named:mangled:)", message: "Please use a new function that returns as an array")
+    @_disfavoredOverload
     public func symbol(
         named name: String,
         mangled: Bool = true
@@ -394,6 +396,8 @@ extension MachORepresentable where Symbol == MachOImage.Symbol {
         return []
     }
 
+    @available(*, deprecated, renamed: "symbols(named:mangled:)", message: "Please use a new function that returns as an array")
+    @_disfavoredOverload
     public func symbol(
         named name: String,
         mangled: Bool = true

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -173,7 +173,16 @@ public protocol MachORepresentable {
     /// - Parameters:
     ///   - name: Symbol name to find
     ///   - mangled: A boolean value that indicates whether the specified name is mangled with Swift
+    /// - Returns: Matched symbols
+    func symbols(named name: String, mangled: Bool) -> [Symbol]
+
+    /// Find the symbol matching the given name.
+    /// - Parameters:
+    ///   - name: Symbol name to find
+    ///   - mangled: A boolean value that indicates whether the specified name is mangled with Swift
     /// - Returns: Matched symbol
+    @available(*, deprecated, renamed: "symbols(named:mangled:)", message: "Please use a new function that returns as an array")
+    @_disfavoredOverload
     func symbol(named name: String, mangled: Bool) -> Symbol?
 }
 
@@ -352,27 +361,43 @@ extension MachORepresentable {
 }
 
 extension MachORepresentable where Symbol == MachOFile.Symbol {
+    public func symbols(
+        named name: String,
+        mangled: Bool = true
+    ) -> [Symbol] {
+        if is64Bit, let symbols64 {
+            return symbols64.named(name, mangled: mangled)
+        } else if let symbols32 {
+            return symbols32.named(name, mangled: mangled)
+        }
+        return []
+    }
+
     public func symbol(
         named name: String,
         mangled: Bool = true
     ) -> Symbol? {
-        if is64Bit {
-            return symbols64?.named(name, mangled: mangled)
-        } else {
-            return symbols32?.named(name, mangled: mangled)
-        }
+        symbols(named: name, mangled: mangled).first
     }
 }
 
 extension MachORepresentable where Symbol == MachOImage.Symbol {
+    public func symbols(
+        named name: String,
+        mangled: Bool = true
+    ) -> [Symbol] {
+        if is64Bit, let symbols64 {
+            return symbols64.named(name, mangled: mangled)
+        } else if let symbols32 {
+            return symbols32.named(name, mangled: mangled)
+        }
+        return []
+    }
+
     public func symbol(
         named name: String,
         mangled: Bool = true
     ) -> Symbol? {
-        if is64Bit {
-            return symbols64?.named(name, mangled: mangled)
-        } else {
-            return symbols32?.named(name, mangled: mangled)
-        }
+        symbols(named: name, mangled: mangled).first
     }
 }

--- a/Tests/MachOKitTests/MachOFilePrintTests.swift
+++ b/Tests/MachOKitTests/MachOFilePrintTests.swift
@@ -518,7 +518,7 @@ extension MachOFilePrintTests {
             "_" + name == symbol.name
         )
 
-        guard let symbol2 = machO.symbol(named: demangledName, mangled: false) else {
+        guard let symbol2 = machO.symbols(named: demangledName, mangled: false).first else {
             XCTFail("not found symbol named \"\(demangledName)\"")
             return
         }

--- a/Tests/MachOKitTests/MachOFilePrintTests.swift
+++ b/Tests/MachOKitTests/MachOFilePrintTests.swift
@@ -505,10 +505,10 @@ extension MachOFilePrintTests {
 
 extension MachOFilePrintTests {
     func testFindSymbolByName() {
-        let name = "$s15GroupActivities0A16SessionMessengerC8MessagesV8IteratorV4nextx_AC14MessageContextVtSgyYaF"
-        let demangledName = "GroupActivities.GroupSessionMessenger.Messages.Iterator.next() async -> Swift.Optional<(A, GroupActivities.GroupSessionMessenger.MessageContext)>"
+        let name = "$ss9CodingKeyP9CoherenceAC15IntCaseIterableRzs0eF0RzrlE8intCasesShySiGvgZ"
+        let demangledName = "async function pointer to dispatch thunk of Swift.Clock.sleep(until: A.Instant, tolerance: Swift.Optional<A.Duration>) async throws -> ()"
 
-        guard let symbol = machO.symbol(named: name) else {
+        guard let symbol = machO.symbols(named: name).first else {
             XCTFail("not found symbol named \"\(name)\"")
             return
         }

--- a/Tests/MachOKitTests/MachOPrintTests.swift
+++ b/Tests/MachOKitTests/MachOPrintTests.swift
@@ -450,7 +450,7 @@ extension MachOPrintTests {
         let name = "$s13MachOKitTests0a10OFilePrintC0C11testSymbolsyyKF0aB011LoadCommandOAE05DylibI0VcAGmcfu_AgIcfu0_"
         let demangledName = "MachOKitTests.MachOFilePrintTests.testLinkerOptionCommand() -> ()"
 
-        guard let symbol = machO.symbol(named: name) else {
+        guard let symbol = machO.symbols(named: name).first else {
             XCTFail("not found symbol named \"\(name)\"")
             return
         }
@@ -460,7 +460,7 @@ extension MachOPrintTests {
             "_" + name == symbol.name
         )
 
-        guard let symbol2 = machO.symbol(named: demangledName, mangled: false) else {
+        guard let symbol2 = machO.symbols(named: demangledName, mangled: false).first else {
             XCTFail("not found symbol named \"\(demangledName)\"")
             return
         }
@@ -589,9 +589,9 @@ extension MachOPrintTests {
     func testStaticSymbolSearchByName() {
         let name = "$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF"
         let symbols = MachOImage.symbols(named: name, mangled: true)
-        for (image, symbol) in symbols {
+        for (image, symbols) in symbols {
             if let path = image.path {
-                print(path, symbol.nlist.sectionNumber?.description ?? "NO_SECT")
+                print(path, symbols.first?.nlist.sectionNumber?.description ?? "NO_SECT")
             }
         }
     }


### PR DESCRIPTION
In some cases, there may be more than one symbol in the Symbol table with the same name or offset.