### PR TITLE
Support `dylib_use_command` introduced from macOS 15, iOS 18

### DIFF
--- a/Sources/MachOKit/LoadCommand/DylibUseCommand.swift
+++ b/Sources/MachOKit/LoadCommand/DylibUseCommand.swift
@@ -1,0 +1,74 @@
+//
+//  DylibUseCommand.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2024/12/12
+//
+//
+
+import Foundation
+
+public struct DylibUseCommand: LoadCommandWrapper {
+    public typealias Layout = dylib_use_command
+
+    public var layout: Layout
+    public var offset: Int // offset from mach header trailing
+
+    init(_ layout: Layout, offset: Int) {
+        self.layout = layout
+        self.offset = offset
+    }
+}
+
+extension DylibUseCommand {
+    public var flags: DylibUseFlags {
+        .init(rawValue: layout.flags)
+    }
+}
+
+extension DylibUseCommand {
+    public func dylib(cmdsStart: UnsafeRawPointer) -> Dylib {
+        let ptr = cmdsStart
+            .advanced(by: offset)
+            .advanced(by: Int(layout.nameoff))
+            .assumingMemoryBound(to: CChar.self)
+
+        return .init(
+            name: String(cString: ptr),
+            timestamp: Date(timeIntervalSince1970: TimeInterval(layout.marker)),
+            currentVersion: .init(layout.current_version),
+            compatibilityVersion: .init(layout.compat_version)
+        )
+    }
+}
+
+extension DylibUseCommand {
+    public func dylib(in machO: MachOFile) -> Dylib {
+        let offset = machO.cmdsStartOffset + offset + Int(layout.nameoff)
+        // swap is not needed
+        let string = machO.fileHandle.readString(
+            offset: numericCast(offset),
+            size: Int(layout.cmdsize) - layoutSize
+        ) ?? ""
+
+        return .init(
+            name: string,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(layout.marker)),
+            currentVersion: .init(layout.current_version),
+            compatibilityVersion: .init(layout.compat_version)
+        )
+    }
+}
+
+public func swap_dylib_use_command(
+    _ dl: UnsafeMutablePointer<dylib_use_command>!,
+    _ target_byte_sex: NXByteOrder
+) {
+    dl.pointee.cmd = dl.pointee.cmd.byteSwapped
+    dl.pointee.cmdsize = dl.pointee.cmdsize.byteSwapped
+    dl.pointee.nameoff = dl.pointee.nameoff.byteSwapped
+    dl.pointee.marker = dl.pointee.marker.byteSwapped
+    dl.pointee.current_version = dl.pointee.current_version.byteSwapped
+    dl.pointee.compat_version = dl.pointee.compat_version.byteSwapped
+    dl.pointee.flags = dl.pointee.flags.byteSwapped
+}

--- a/Sources/MachOKit/LoadCommand/Model/Dylib.swift
+++ b/Sources/MachOKit/LoadCommand/Model/Dylib.swift
@@ -21,3 +21,10 @@ public struct Dylib {
     /// library's compatibility vers number
     public var compatibilityVersion: Version
 }
+
+extension Dylib {
+    /// A boolean value that indicates whether self is loaded from `dylib_use_command`
+    public var isFromDylibUseCommand: Bool {
+        timestamp.timeIntervalSince1970 == TimeInterval(DYLIB_USE_MARKER)
+    }
+}

--- a/Sources/MachOKit/LoadCommand/Model/DylibUseFlags.swift
+++ b/Sources/MachOKit/LoadCommand/Model/DylibUseFlags.swift
@@ -1,0 +1,85 @@
+//
+//  DylibUseFlags.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2024/12/12
+//
+//
+
+import Foundation
+
+public struct DylibUseFlags: BitFlags {
+    public typealias RawValue = UInt32
+
+    public let rawValue: RawValue
+
+    public init(rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+}
+
+extension DylibUseFlags {
+    /// DYLIB_USE_WEAK_LINK
+    public static let weak_link = MachHeader.Flags(
+        rawValue: Bit.weak_link.rawValue
+    )
+    /// DYLIB_USE_REEXPORT
+    public static let reexport = MachHeader.Flags(
+        rawValue: Bit.reexport.rawValue
+    )
+    /// DYLIB_USE_UPWARD
+    public static let upward = MachHeader.Flags(
+        rawValue: Bit.upward.rawValue
+    )
+    /// DYLIB_USE_DELAYED_INIT
+    public static let delayed_init = MachHeader.Flags(
+        rawValue: Bit.delayed_init.rawValue
+    )
+}
+
+extension DylibUseFlags {
+    public enum Bit: CaseIterable {
+        /// DYLIB_USE_WEAK_LINK
+        case weak_link
+        /// DYLIB_USE_REEXPORT
+        case reexport
+        /// DYLIB_USE_UPWARD
+        case upward
+        /// DYLIB_USE_DELAYED_INIT
+        case delayed_init
+    }
+}
+
+extension DylibUseFlags.Bit: RawRepresentable {
+    public typealias RawValue = UInt32
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case RawValue(DYLIB_USE_WEAK_LINK): self = .weak_link
+        case RawValue(DYLIB_USE_REEXPORT): self = .reexport
+        case RawValue(DYLIB_USE_UPWARD): self = .upward
+        case RawValue(DYLIB_USE_DELAYED_INIT): self = .delayed_init
+        default: return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+        case .weak_link: RawValue(DYLIB_USE_WEAK_LINK)
+        case .reexport: RawValue(DYLIB_USE_REEXPORT)
+        case .upward: RawValue(DYLIB_USE_UPWARD)
+        case .delayed_init: RawValue(DYLIB_USE_DELAYED_INIT)
+        }
+    }
+}
+
+extension DylibUseFlags.Bit: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .weak_link: "DYLIB_USE_WEAK_LINK"
+        case .reexport: "DYLIB_USE_REEXPORT"
+        case .upward: "DYLIB_USE_UPWARD"
+        case .delayed_init: "DYLIB_USE_DELAYED_INIT"
+        }
+    }
+}

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -127,11 +127,19 @@ extension MachOFile {
         for cmd in loadCommands {
             switch cmd {
             case let .loadDylib(cmd):
+                var flags: DylibUseFlags = []
+                if let dylibUseCmd = cmd.dylibUseCommand(in: self) {
+                    flags = dylibUseCmd.flags
+                }
                 let lib = cmd.dylib(in: self)
-                dependencies.append(.init(dylib: lib, type: .load))
+                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
             case let .loadWeakDylib(cmd):
+                var flags: DylibUseFlags = []
+                if let dylibUseCmd = cmd.dylibUseCommand(in: self) {
+                    flags = dylibUseCmd.flags
+                }
                 let lib = cmd.dylib(in: self)
-                dependencies.append(.init(dylib: lib, type: .weakLoad))
+                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
             case let .reexportDylib(cmd):
                 let lib = cmd.dylib(in: self)
                 dependencies.append(.init(dylib: lib, type: .reexport))

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -151,11 +151,19 @@ extension MachOImage {
         for cmd in loadCommands {
             switch cmd {
             case let .loadDylib(cmd):
+                var flags: DylibUseFlags = []
+                if let dylibUseCmd = cmd.dylibUseCommand(in: self) {
+                    flags = dylibUseCmd.flags
+                }
                 let lib = cmd.dylib(cmdsStart: cmdsStartPtr)
-                dependencies.append(.init(dylib: lib, type: .load))
+                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
             case let .loadWeakDylib(cmd):
+                var flags: DylibUseFlags = []
+                if let dylibUseCmd = cmd.dylibUseCommand(in: self) {
+                    flags = dylibUseCmd.flags
+                }
                 let lib = cmd.dylib(cmdsStart: cmdsStartPtr)
-                dependencies.append(.init(dylib: lib, type: .weakLoad))
+                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
             case let .reexportDylib(cmd):
                 let lib = cmd.dylib(cmdsStart: cmdsStartPtr)
                 dependencies.append(.init(dylib: lib, type: .reexport))

--- a/Sources/MachOKit/Model/DependedDylib.swift
+++ b/Sources/MachOKit/Model/DependedDylib.swift
@@ -19,4 +19,15 @@ public struct DependedDylib {
 
     public let dylib: Dylib
     public let type: DependType
+    public let useFlags: DylibUseFlags
+
+    init(
+        dylib: Dylib,
+        type: DependType,
+        useFlags: DylibUseFlags = []
+    ) {
+        self.dylib = dylib
+        self.type = type
+        self.useFlags = useFlags
+    }
 }

--- a/Tests/MachOKitTests/MachOFilePrintTests.swift
+++ b/Tests/MachOKitTests/MachOFilePrintTests.swift
@@ -189,12 +189,15 @@ final class MachOFilePrintTests: XCTestCase {
 
     func testDependencies() throws {
         for dependency in machO.dependencies {
-            let dependency = dependency.dylib
+            let dylib = dependency.dylib
             print("----")
-            print("Name:", dependency.name)
-            print("CurrentVersion:", dependency.currentVersion)
-            print("CompatibilityVersion:", dependency.compatibilityVersion)
-            print("TimeStamp:", dependency.timestamp)
+            print("Name:", dylib.name)
+            print("CurrentVersion:", dylib.currentVersion)
+            print("CompatibilityVersion:", dylib.compatibilityVersion)
+            print("TimeStamp:", dylib.timestamp)
+            if dependency.dylib.isFromDylibUseCommand {
+                print("Flags", dependency.useFlags.bits)
+            }
         }
     }
 

--- a/Tests/MachOKitTests/MachOPrintTests.swift
+++ b/Tests/MachOKitTests/MachOPrintTests.swift
@@ -120,12 +120,15 @@ final class MachOPrintTests: XCTestCase {
 
     func testDependencies() throws {
         for dependency in machO.dependencies {
-            let dependency = dependency.dylib
+            let dylib = dependency.dylib
             print("----")
-            print("Name:", dependency.name)
-            print("CurrentVersion:", dependency.currentVersion)
-            print("CompatibilityVersion:", dependency.compatibilityVersion)
-            print("TimeStamp:", dependency.timestamp)
+            print("Name:", dylib.name)
+            print("CurrentVersion:", dylib.currentVersion)
+            print("CompatibilityVersion:", dylib.compatibilityVersion)
+            print("TimeStamp:", dylib.timestamp)
+            if dependency.dylib.isFromDylibUseCommand {
+                print("Flags", dependency.useFlags.bits)
+            }
         }
     }
 


### PR DESCRIPTION
closes #148 