### PR TITLE
Use Xcode15 for building xcframework in Github Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,18 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.2.app
+  DEVELOPER_DIR: /Applications/Xcode_15.2.app
 
 jobs:
   build:
     name: Release
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select Xcode 15
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Install visionOS
         run: |


### PR DESCRIPTION
- #153
- #156

The pre-built binary is not backward compatible, so if you build with Xcode16, it will not be available for Xcode15 or earlier environments.