### PR TITLE
Convert raw vmaddr to file offset

### DIFF
--- a/Sources/MachOKit/Model/CoreFoundation/CFString.swift
+++ b/Sources/MachOKit/Model/CoreFoundation/CFString.swift
@@ -87,10 +87,13 @@ extension CFString32 {
 
 extension CFStringProtocol {
     public func string(in machO: MachOFile) -> String? {
-        let offset = machO.headerStartOffset + stringOffset
+        let offset =  machO.fileOffset(
+            of: numericCast(stringOffset)
+        ) + numericCast(machO.headerStartOffset)
+
         if isUnicode {
             let data = machO.fileHandle.readData(
-                offset: UInt64(offset),
+                offset: offset,
                 size: numericCast(stringSize) * numericCast(MemoryLayout<UInt16/*UniChar*/>.size)
             )
             return String(bytes: data, encoding: .utf16LittleEndian)


### PR DESCRIPTION
Binaries supporting platforms prior to macOS12 may use absolute addresses for vmaddr.
In such a case, you need to add a process to convert it to file offset.

We have implemented a function to convert to file offset, taking into account the tagged pointer of PAC and objc, and the range of valid vmaddr.