### PR TITLE
Add methods to search in trie tree with key prefix

### DIFF
--- a/Sources/MachOKit/Extension/TrieTreeProtocol+.swift
+++ b/Sources/MachOKit/Extension/TrieTreeProtocol+.swift
@@ -33,8 +33,8 @@ extension TrieTreeProtocol where Content == ExportTrieNodeContent {
             }
     }
 
-    public func search(for key: String) -> ExportedSymbol? {
-        guard let (_, content) = _search(for: key) else {
+    public func search(by key: String) -> ExportedSymbol? {
+        guard let (_, content) = _search(by: key) else {
             return nil
         }
         let symbolOffset: Int? = if let symbolOffset = content.symbolOffset {
@@ -65,8 +65,8 @@ extension TrieTreeProtocol where Content == DylibsTrieNodeContent {
         }
     }
 
-    public func search(for key: String) -> DylibIndex? {
-        guard let (_, content) = _search(for: key) else {
+    public func search(by key: String) -> DylibIndex? {
+        guard let (_, content) = _search(by: key) else {
             return nil
         }
         return.init(name: key, index: content.index)
@@ -85,8 +85,8 @@ extension TrieTreeProtocol where Content == ProgramsTrieNodeContent {
         }
     }
 
-    public func search(for key: String) -> ProgramOffset? {
-        guard let (_, content) = _search(for: key) else {
+    public func search(by key: String) -> ProgramOffset? {
+        guard let (_, content) = _search(by: key) else {
             return nil
         }
         return.init(name: key, offset: content.offset)

--- a/Sources/MachOKit/Extension/TrieTreeProtocol+.swift
+++ b/Sources/MachOKit/Extension/TrieTreeProtocol+.swift
@@ -51,6 +51,26 @@ extension TrieTreeProtocol where Content == ExportTrieNodeContent {
             resolverOffset: content.resolver
         )
     }
+
+    public func search(byKeyPrefix prefix: String) -> [ExportedSymbol] {
+        let found = _search(byKeyPrefix: prefix)
+        return found.compactMap {
+            let content = $0.content
+            let symbolOffset: Int? = if let symbolOffset = content.symbolOffset {
+                .init(bitPattern: symbolOffset)
+            } else { nil }
+
+            return .init(
+                name: $0.name,
+                offset: symbolOffset,
+                flags: content.flags ?? [],
+                ordinal: content.ordinal,
+                importedName: content.importedName,
+                stub: content.stub,
+                resolverOffset: content.resolver
+            )
+        }
+    }
 }
 
 extension TrieTreeProtocol where Content == DylibsTrieNodeContent {
@@ -71,6 +91,13 @@ extension TrieTreeProtocol where Content == DylibsTrieNodeContent {
         }
         return.init(name: key, index: content.index)
     }
+
+    public func search(byKeyPrefix prefix: String) -> [DylibIndex] {
+        let found = _search(byKeyPrefix: prefix)
+        return found.compactMap {
+            return .init(name: $0.name, index: $0.content.index)
+        }
+    }
 }
 
 extension TrieTreeProtocol where Content == ProgramsTrieNodeContent {
@@ -90,5 +117,12 @@ extension TrieTreeProtocol where Content == ProgramsTrieNodeContent {
             return nil
         }
         return.init(name: key, offset: content.offset)
+    }
+
+    public func search(byKeyPrefix prefix: String) -> [ProgramOffset] {
+        let found = _search(byKeyPrefix: prefix)
+        return found.compactMap {
+            return .init(name: $0.name, offset: $0.content.offset)
+        }
     }
 }

--- a/Sources/MachOKit/MachOFile+ExportTrie.swift
+++ b/Sources/MachOKit/MachOFile+ExportTrie.swift
@@ -58,8 +58,8 @@ extension MachOFile.ExportTrie {
     /// Search the trie tree by symbol name to get the expoted symbol
     /// - Parameter key: symbol name
     /// - Returns: If found, retruns exported symbol
-    public func search(for key: String) -> ExportedSymbol? {
-        wrapped.search(for: key)
+    public func search(by key: String) -> ExportedSymbol? {
+        wrapped.search(by: key)
     }
 }
 

--- a/Sources/MachOKit/MachOFile+ExportTrie.swift
+++ b/Sources/MachOKit/MachOFile+ExportTrie.swift
@@ -61,6 +61,13 @@ extension MachOFile.ExportTrie {
     public func search(by key: String) -> ExportedSymbol? {
         wrapped.search(by: key)
     }
+
+    /// Search the trie tree by prefix of symbol name to get the expoted symbol
+    /// - Parameter prefix: prefix of symbol name
+    /// - Returns: If found, retruns exported symbol
+    public func search(byKeyPrefix prefix: String) -> [ExportedSymbol] {
+        wrapped.search(byKeyPrefix: prefix)
+    }
 }
 
 extension MachOFile.ExportTrie {

--- a/Sources/MachOKit/MachOImage+ExportTrie.swift
+++ b/Sources/MachOKit/MachOImage+ExportTrie.swift
@@ -68,6 +68,13 @@ extension MachOImage.ExportTrie {
     public func search(by key: String) -> ExportedSymbol? {
         wrapped.search(by: key)
     }
+
+    /// Search the trie tree by prefix of symbol name to get the expoted symbol
+    /// - Parameter prefix: prefix of symbol name
+    /// - Returns: If found, retruns exported symbol
+    public func search(byKeyPrefix prefix: String) -> [ExportedSymbol] {
+        wrapped.search(byKeyPrefix: prefix)
+    }
 }
 
 extension MachOImage.ExportTrie {

--- a/Sources/MachOKit/MachOImage+ExportTrie.swift
+++ b/Sources/MachOKit/MachOImage+ExportTrie.swift
@@ -65,8 +65,8 @@ extension MachOImage.ExportTrie {
     /// Search the trie tree by symbol name to get the expoted symbol
     /// - Parameter key: symbol name
     /// - Returns: If found, retruns exported symbol
-    public func search(for key: String) -> ExportedSymbol? {
-        wrapped.search(for: key)
+    public func search(by key: String) -> ExportedSymbol? {
+        wrapped.search(by: key)
     }
 }
 

--- a/Sources/MachOKit/Util/TrieTree/Model/TrieNode.swift
+++ b/Sources/MachOKit/Util/TrieTree/Model/TrieNode.swift
@@ -38,6 +38,12 @@ public struct TrieNode<Content: TrieNodeContent> {
 }
 
 extension TrieNode {
+    public var isTerminal: Bool {
+        terminalSize != 0
+    }
+}
+
+extension TrieNode {
     public static func readNext(
         basePointer: UnsafePointer<UInt8>,
         trieSize: Int,

--- a/Sources/MachOKit/Util/TrieTree/Protocol/TrieTreeProtocol.swift
+++ b/Sources/MachOKit/Util/TrieTree/Protocol/TrieTreeProtocol.swift
@@ -85,7 +85,7 @@ extension TrieTreeProtocol {
     /// Search the trie tree by name to get terminal content and node offset
     /// - Parameter key: name
     /// - Returns: If found, retruns terminal content and node offset
-    public func _search(for key: String) -> (offset: Int, content: Content)? {
+    public func _search(by key: String) -> (offset: Int, content: Content)? {
         guard !key.isEmpty else { return nil }
 
         var currentLabel = ""

--- a/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
+++ b/Tests/MachOKitTests/DyldCacheLoadedPrintTests.swift
@@ -173,7 +173,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
             })
         let trie = cache.dylibsTrie
         for index in indices {
-            let found = trie?.search(for: index.name)
+            let found = trie?.search(by: index.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.index, index.index)
 
@@ -186,7 +186,7 @@ final class DyldCacheLoadedPrintTests: XCTestCase {
         let programOffsets = cache.programOffsets
         let trie = cache.programsTrie
         for programOffset in programOffsets {
-            let found = trie?.search(for: programOffset.name)
+            let found = trie?.search(by: programOffset.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.offset, programOffset.offset)
 

--- a/Tests/MachOKitTests/DyldCachePrintTests.swift
+++ b/Tests/MachOKitTests/DyldCachePrintTests.swift
@@ -180,7 +180,7 @@ final class DyldCachePrintTests: XCTestCase {
             })
         let trie = cache.dylibsTrie
         for index in indices {
-            let found = trie?.search(for: index.name)
+            let found = trie?.search(by: index.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.index, index.index)
 
@@ -193,7 +193,7 @@ final class DyldCachePrintTests: XCTestCase {
         let programOffsets = cache.programOffsets
         let trie = cache.programsTrie
         for programOffset in programOffsets {
-            let found = trie?.search(for: programOffset.name)
+            let found = trie?.search(by: programOffset.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.offset, programOffset.offset)
             print(programOffset.offset, programOffset.name)

--- a/Tests/MachOKitTests/MachOFilePrintTests.swift
+++ b/Tests/MachOKitTests/MachOFilePrintTests.swift
@@ -382,7 +382,7 @@ extension MachOFilePrintTests {
             print("----")
             print("0x" + String(symbol.offset ?? 0, radix: 16), symbol.name)
 
-            let found = machO.exportTrie?.search(for: symbol.name)
+            let found = machO.exportTrie?.search(by: symbol.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.offset, symbol.offset)
 

--- a/Tests/MachOKitTests/MachOPrintTests.swift
+++ b/Tests/MachOKitTests/MachOPrintTests.swift
@@ -313,7 +313,7 @@ extension MachOPrintTests {
             print("----")
             print("0x" + String(symbol.offset ?? 0, radix: 16), symbol.name)
 
-            let found = machO.exportTrie?.search(for: symbol.name)
+            let found = machO.exportTrie?.search(by: symbol.name)
             XCTAssertNotNil(found)
             XCTAssertEqual(found?.offset, symbol.offset)
 


### PR DESCRIPTION
```swift
guard let exportTrie = machO.exportTrie else { return }
let prefix = "_$s"
let swiftSymbols = exportTrie.search(byKeyPrefix: prefix)
```