### PR TITLE
Fix 32-bit overflow issue in string table endianness detection

### DIFF
--- a/Sources/MachOKit/MachOFile+Strings.swift
+++ b/Sources/MachOKit/MachOFile+Strings.swift
@@ -112,7 +112,7 @@ extension MachOFile.UnicodeStrings.Iterator {
         case 2:
             return ptr.pointee == 0xFFFE /* ZERO WIDTH NO-BREAK SPACE (swapped) */
         case 4:
-            return ptr.pointee == 0xFFFE0000
+            return ptr.pointee == UInt32(0xFFFE0000) // avoid overflows in 32bit env
         default:
             return false
         }

--- a/Sources/MachOKit/MachOImage+Strings.swift
+++ b/Sources/MachOKit/MachOImage+Strings.swift
@@ -121,7 +121,7 @@ extension MachOImage.UnicodeStrings.Iterator {
         case 2:
             return ptr.pointee == 0xFFFE /* ZERO WIDTH NO-BREAK SPACE (swapped) */
         case 4:
-            return ptr.pointee == 0xFFFE0000
+            return ptr.pointee == 0xFFFE0000 // avoid overflows in 32bit env
         default:
             return false
         }


### PR DESCRIPTION
```
/Users/runner/work/MachOKit/MachOKit/Sources/MachOKit/MachOFile+Strings.swift:115:35: error: integer literal '4294836224' overflows when stored into 'Int'
            return ptr.pointee == 0xFFFE0000
```