### PR TITLE
Add method to check if specified address is contained in mach-o

### DIFF
--- a/Sources/MachOKit/LoadCommand/SegmentCommand.swift
+++ b/Sources/MachOKit/LoadCommand/SegmentCommand.swift
@@ -43,6 +43,12 @@ extension SegmentCommandProtocol {
     }
 }
 
+extension SegmentCommandProtocol {
+    public func contains(unslidAddress address: UInt64) -> Bool {
+        virtualMemoryAddress <= address && address < virtualMemoryAddress + virtualMemorySize
+    }
+}
+
 public struct SegmentCommand: SegmentCommandProtocol {
     public typealias Layout = segment_command
     public typealias SectionType = Section

--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -227,17 +227,19 @@ fileprivate extension MachOImage {
         from ptr: UnsafeRawPointer
     ) -> Int? {
         let slide = vmaddrSlide ?? 0
-        let address = Int(bitPattern: ptr) - slide
+        let address = Int(bitPattern: ptr)
+        if slide > address { return nil }
+
+        let unslidAddress = address - slide
 
         var bestDistance: Int?
         for segment in segments {
-            if segment.virtualMemoryAddress <= address,
-               address < segment.virtualMemoryAddress + segment.virtualMemorySize {
+            if segment.contains(unslidAddress: numericCast(unslidAddress)) {
                 return 0
             }
             let distance = min(
-                abs(segment.virtualMemoryAddress - address),
-                abs(segment.virtualMemoryAddress + segment.virtualMemorySize - address)
+                abs(segment.virtualMemoryAddress - unslidAddress),
+                abs(segment.virtualMemoryAddress + segment.virtualMemorySize - unslidAddress)
             )
             if distance < bestDistance ?? .max {
                 bestDistance = distance

--- a/Sources/MachOKit/MachOImage+static.swift
+++ b/Sources/MachOKit/MachOImage+static.swift
@@ -69,13 +69,12 @@ extension MachOImage {
         at address: UnsafeRawPointer,
         isGlobalOnly: Bool = false
     ) -> (MachOImage, Symbol)? {
-        for image in images where image.contains(ptr: address) {
-            if let symbol = image.closestSymbol(
-                at: address,
-                isGlobalOnly: isGlobalOnly
-            ) {
-                return (image, symbol)
-            }
+        if let image = image(containing: address),
+           let symbol = image.closestSymbol(
+            at: address,
+            isGlobalOnly: isGlobalOnly
+           ) {
+            return (image, symbol)
         }
         guard let closestImage = closestImage(at: address),
               let symbol = closestImage.closestSymbol(
@@ -98,7 +97,7 @@ extension MachOImage {
         at address: UnsafeRawPointer,
         isGlobalOnly: Bool = false
     ) -> (MachOImage, [Symbol])? {
-        for image in images where image.contains(ptr: address) {
+        if let image = image(containing: address) {
             let symbols = image.closestSymbols(
                 at: address,
                 isGlobalOnly: isGlobalOnly
@@ -107,6 +106,7 @@ extension MachOImage {
                 return (image, symbols)
             }
         }
+
         guard let closestImage = closestImage(at: address) else {
             return nil
         }
@@ -131,13 +131,14 @@ extension MachOImage {
         for address: UnsafeRawPointer,
         isGlobalOnly: Bool = false
     ) -> (MachOImage, Symbol)? {
-        for image in images where image.contains(ptr: address) {
-            if let symbol = image.symbol(
-                for: address,
-                isGlobalOnly: isGlobalOnly
-            ) {
-                return (image, symbol)
-            }
+        guard let image = image(containing: address) else {
+            return nil
+        }
+        if let symbol = image.symbol(
+            for: address,
+            isGlobalOnly: isGlobalOnly
+        ) {
+            return (image, symbol)
         }
         return nil
     }

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -763,3 +763,15 @@ extension MachOImage {
         )
     }
 }
+
+extension MachOImage {
+    /// Determines whether the specified pointer is contained within any segment of the Mach-O binary.
+    ///
+    /// - Parameter ptr: The pointer to check.
+    /// - Returns: `true` if the address is within any segment; otherwise, `false`.
+    public func contains(ptr: UnsafeRawPointer) -> Bool {
+        let slide = vmaddrSlide ?? 0
+        let address = Int(bitPattern: ptr) - slide
+        return contains(unslidAddress: numericCast(address))
+    }
+}

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -771,7 +771,11 @@ extension MachOImage {
     /// - Returns: `true` if the address is within any segment; otherwise, `false`.
     public func contains(ptr: UnsafeRawPointer) -> Bool {
         let slide = vmaddrSlide ?? 0
-        let address = Int(bitPattern: ptr) - slide
-        return contains(unslidAddress: numericCast(address))
+        let address = Int(bitPattern: ptr)
+
+        if slide > address { return false }
+
+        let unslidAddress = address - slide
+        return contains(unslidAddress: numericCast(unslidAddress))
     }
 }

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -838,12 +838,10 @@ extension MachORepresentable where IndirectSymbols.Index == Int {
 
 extension MachORepresentable {
     public func contains(unslidAddress address: UInt64) -> Bool {
-        for segment in self.segments {
-            if segment.virtualMemoryAddress <= address,
-               address < segment.virtualMemoryAddress + segment.virtualMemorySize {
-                return true
+        segments.contains(
+            where: {
+                $0.contains(unslidAddress: address)
             }
-        }
-        return false
+        )
     }
 }


### PR DESCRIPTION
Not all segments, such as mach-o in the dyld cache, are located in contiguous memory space.

In the previous logic, a segment was considered to be included if it was larger than the address of the first segment and smaller than the address of the end of the last segment.
However, this was a mistake.