### PR TITLE
Retain the dyld_shared_cache to which one belongs

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
@@ -64,7 +64,9 @@ public enum DyldSubCacheEntry: Sendable {
 extension DyldSubCacheEntry {
     public func subcache(for cache: DyldCache) throws -> DyldCache? {
         let url = URL(fileURLWithPath: cache.url.path + fileSuffix)
-        return try DyldCache(subcacheUrl: url, mainCacheHeader: cache.header)
+        let subcache = try DyldCache(subcacheUrl: url, mainCache: cache)
+        subcache._fullCache = cache._fullCache
+        return subcache
     }
 
     public func subcache(for cache: DyldCacheLoaded) throws -> DyldCacheLoaded? {

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
@@ -133,7 +133,8 @@ extension ObjCHeaderInfoRO64 {
         return try? .init(
             url: cache.url,
             imagePath: imagePath ?? "",
-            headerStartOffsetInCache: numericCast(offset)
+            headerStartOffsetInCache: numericCast(offset),
+            cache: cache
         )
     }
 
@@ -157,10 +158,20 @@ extension ObjCHeaderInfoRO64 {
             return nil
         }
         let imagePath = imagePath(in: cache)
+
+        let _cache: DyldCache = .init(
+            unsafeFileHandle: segment._file,
+            url: url,
+            cpu: cache.cpu,
+            mainCache: segment.offset == 0 ? nil : cache.mainCache
+        )
+        _cache._fullCache = cache
+
         return try? .init(
             url: url,
             imagePath: imagePath ?? "",
-            headerStartOffsetInCache: numericCast(offset) - segment.offset
+            headerStartOffsetInCache: numericCast(offset) - segment.offset,
+            cache: _cache
         )
     }
 }
@@ -238,7 +249,8 @@ extension ObjCHeaderInfoRO32 {
         return try? .init(
             url: cache.url,
             imagePath: imagePath ?? "",
-            headerStartOffsetInCache: numericCast(offset)
+            headerStartOffsetInCache: numericCast(offset),
+            cache: cache
         )
     }
 
@@ -262,10 +274,20 @@ extension ObjCHeaderInfoRO32 {
             return nil
         }
         let imagePath = imagePath(in: cache)
+
+        let _cache: DyldCache = .init(
+            unsafeFileHandle: segment._file,
+            url: url,
+            cpu: cache.cpu,
+            mainCache: segment.offset == 0 ? nil : cache.mainCache
+        )
+        _cache._fullCache = cache
+
         return try? .init(
             url: url,
             imagePath: imagePath ?? "",
-            headerStartOffsetInCache: numericCast(offset) - segment.offset
+            headerStartOffsetInCache: numericCast(offset) - segment.offset,
+            cache: _cache
         )
     }
 }


### PR DESCRIPTION
- Initializing `DyldCache` or `FullDyldCache` every time to access the cache is inefficient.
    - Each time, the file is mapped into memory using mmap and then discarded immediately.
- However, up until now, we have avoided retaining it from the perspective of biosynthesis during parallel execution.
    - Previously, `Foundation.FileHandle` was used for reading files, resulting in a structure that repeatedly performed seek and read operations.
    - https://github.com/p-x9/MachOKit/pull/195
    - Currently, since it only reads values that have been loaded into memory, there is no issue.
- This PR minimizes the number of times files need to be expanded into memory.