### PR TITLE
Fix offset calculation in OldObjCOptimization layout retrieval

### DIFF
--- a/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
+++ b/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
@@ -135,7 +135,9 @@ extension _DyldCacheFileRepresentable {
             __objc_opt_ro = section
         }
 
-        let offset = __objc_opt_ro.offset + libobjc.headerStartOffset
+        guard let offset = fileOffset(of: numericCast(__objc_opt_ro.address)) else {
+            return nil
+        }
         let layout: OldObjCOptimization.Layout = try! fileHandle.read(
             offset: numericCast(offset)
         )


### PR DESCRIPTION
`section.offset` is file offset.
For mach-o files within a subcache, this represents the offset within that subcache file.