### PR TITLE
Add iOS installation steps to DocC workflow

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -11,15 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
-
-      - name: Install iOS
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          sudo xcrun simctl list
-          sudo xcodebuild -downloadPlatform iOS
-          sudo xcodebuild -runFirstLaunch
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Build DocC
         run: |


### PR DESCRIPTION
- Run initial setup for Xcode and download iOS platform

## Related
- https://github.com/actions/runner-images/issues/12541
- https://github.com/p-x9/MachOKit/actions/runs/19140921544/job/54705455736
- https://github.com/actions/runner-images/blob/10901db80b7cf5908d23bffdb5e97950664b76ff/images/macos/toolsets/toolset-15.json