### PR TITLE
Fix fileSuffix formatting in `DyldSubCacheEntryV1`

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
@@ -100,9 +100,9 @@ extension DyldSubCacheEntryV1 {
 
     /// File name suffix of the subCache file
     ///
-    /// e.g. ".01", ".02"
+    /// e.g. ".1", ".2"
     public var fileSuffix: String {
-        "." + String(format: "%02d", index)
+        "." + String(format: "%u", index + 1)
     }
 }
 


### PR DESCRIPTION
- Updated suffix format from "%02d" to "%u" for correct numbering
- Changed example suffixes from ".01", ".02" to ".1", ".2"

https://github.com/apple-oss-distributions/dyld/blob/637911768f664e38e7e50b4fbf17e303e14fdc01/other-tools/dsc_extractor.cpp#L402-L404

<img width="461" height="205" alt="image" src="https://github.com/user-attachments/assets/00f7f42d-58f2-4c23-a13d-2927b60dd345" />

