### PR TITLE
fix: compilation on x86_64-swift-linux-musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Swift
-        # WORKAROUND:https://github.com/swift-actions/setup-swift/pull/680
-        uses: swift-actions/setup-swift@bb83339d1e8577741bdc6c65ba551ce7dc0fb854
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: '6.0.3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         # WORKAROUND:https://github.com/swift-actions/setup-swift/pull/680
         uses: swift-actions/setup-swift@bb83339d1e8577741bdc6c65ba551ce7dc0fb854
         with:
-          swift-version: '5.10.1'
+          swift-version: '6.0.3'
 
       - uses: actions/checkout@v4
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6621026c79da683c5acf7d239a171ec074b1261e7b06f6b7f3787f2cc355d01a",
+  "originHash" : "ad75504b21e5e277c20f3fa0bc59e3ba4af5ec41da7752077a8e23c878737e3e",
   "pins" : [
     {
       "identity" : "objectarchivekit",
@@ -11,12 +11,30 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "swift-binary-parse-support",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-binary-parse-support.git",
       "state" : {
         "revision" : "5fb96b503672ea4752eded6b4e301fd87214b03b",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ad75504b21e5e277c20f3fa0bc59e3ba4af5ec41da7752077a8e23c878737e3e",
+  "originHash" : "e383328a12c016adeaba5a10339bfcb0d2b6fd532be729660d4f9d51fc021693",
   "pins" : [
     {
       "identity" : "objectarchivekit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/ObjectArchiveKit.git",
       "state" : {
-        "revision" : "c47d1b2df06168bacb396a1765ae5bf7fa2868fb",
-        "version" : "0.3.0"
+        "revision" : "96d782a576273b73b277b577943a2a25b00b919e",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,8 @@
 
 import PackageDescription
 
+let linuxPlatforms: [Platform] = [.linux, .openbsd]
+
 let package = Package(
     name: "MachOKit",
     platforms: [
@@ -37,6 +39,10 @@ let package = Package(
             url: "https://github.com/p-x9/ObjectArchiveKit.git",
             from: "0.3.0"
         ),
+        .package(
+            url: "https://github.com/apple/swift-crypto.git",
+            "1.0.0" ..< "4.0.0"
+        ),
     ],
     targets: [
         .target(
@@ -44,7 +50,12 @@ let package = Package(
             dependencies: [
                 "MachOKitC",
                 .product(name: "FileIO", package: "swift-fileio"),
-                .product(name: "FileIOBinary", package: "swift-fileio-extra")
+                .product(name: "FileIOBinary", package: "swift-fileio-extra"),
+                .product(
+                    name: "Crypto",
+                    package: "swift-crypto",
+                    condition: .when(platforms: linuxPlatforms)
+                )
             ],
             swiftSettings: SwiftSetting.allCases + [
                 .enableExperimentalFeature("AccessLevelOnImport", .when(configuration: .debug))
@@ -103,21 +114,6 @@ if isForBinaryKitFramework {
 }
 
 // MARK: - Crypto
-
-#if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) &&  canImport(CommonCrypto)
-/* Do Nothing */
-#else
-package.dependencies += [
-    .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0")
-]
-
-machOKit?.dependencies += [
-    .product(
-        name: "Crypto",
-        package: "swift-crypto"
-    )
-]
-#endif
 
 // https://github.com/treastrain/swift-upcomingfeatureflags-cheatsheet
 extension SwiftSetting {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/p-x9/ObjectArchiveKit.git",
-            from: "0.3.0"
+            from: "0.5.0"
         ),
         .package(
             url: "https://github.com/apple/swift-crypto.git",

--- a/Package.swift
+++ b/Package.swift
@@ -113,8 +113,6 @@ if isForBinaryKitFramework {
     ]
 }
 
-// MARK: - Crypto
-
 // https://github.com/treastrain/swift-upcomingfeatureflags-cheatsheet
 extension SwiftSetting {
     static let forwardTrailingClosures: Self = .enableUpcomingFeature("ForwardTrailingClosures")              // SE-0286, Swift 5.3,  SwiftPM 5.8+


### PR DESCRIPTION
When building for `x86_64-swift-linux-musl`:
```bash
swift build --configuration release --swift-sdk x86_64-swift-linux-musl
```
the build failed with `no such module 'Crypto'` error:
```
warning: 'machokit': /Users/asevko/work/forks/MachOKit/Package.swift:137:1: warning: extension declares a conformance of imported type 'SwiftSetting' to imported protocol 'CaseIterable'; this will not behave correctly if the owners of 'PackageDescription' introduce this conformance in the future
135 | }
136 | 
137 | extension SwiftSetting: CaseIterable {
    | |- warning: extension declares a conformance of imported type 'SwiftSetting' to imported protocol 'CaseIterable'; this will not behave correctly if the owners of 'PackageDescription' introduce this conformance in the future
    | `- note: add '@retroactive' to silence this warning
138 |     public static var allCases: [Self] {
139 |         [
[1/1] Planning build
Building for production...
warning: '--product' cannot be used with the automatic product 'MachOKit'; building the default target instead
/Users/asevko/work/forks/MachOKit/Sources/MachOKit/Model/Codesign/CodeDirectory/CodeSignCodeDirectory.swift:16:16: error: no such module 'Crypto'
 14 | #else
 15 | #if compiler(>=6.0)
 16 | private import Crypto
    |                `- error: no such module 'Crypto'
 17 | #elseif compiler(>=5.10) && hasFeature(AccessLevelOnImport)
 18 | private import Crypto
 ```

That happens when cross-compiling on macOS to linux due to the reason, that
```swift
#if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) &&  canImport(CommonCrypto)
```
evaluates on macOs, so the `swift-crypto` won't be added as a dependency. So we have to declare the package `swift-crypto` **unconditionally**,  **conditionally** link the product for linux platforms.

Note: the `x86_64-swift-linux-musl` toolchain is installed via `swiftly`; the active toolchain should also be managed by `swiftly >= 6.3.0` as on lower versions there was a compiler crash. For validating build on `x86_64-swift-linux-musl` the patch from https://github.com/p-x9/ObjectArchiveKit/pull/5 is also required.