### PR TITLE
Add relative objc method type base address calculation

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
@@ -33,6 +33,20 @@ extension ObjCOptimization {
                 by: numericCast(layout.relativeMethodSelectorBaseAddressOffset)
             )
     }
+
+    /// Relative method list type are offsets from this address
+    /// - Parameter cache: DyldCache to which `self` belongs
+    /// - Returns: relative selector's base address
+    public func relativeMethodTypeBaseAddress(
+        in cache: DyldCacheLoaded
+    ) -> UnsafeRawPointer? {
+        guard layout.version >= 2 else { return nil }
+        let relativeMethodSelectorBaseAddress = relativeMethodSelectorBaseAddress(in: cache)
+        return relativeMethodSelectorBaseAddress
+            .advanced(
+                by: numericCast(layout.relativeMethodSelectorBufferSize)
+            )
+    }
 }
 
 // MARK: Header Optimization RW

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCOptimization.swift
@@ -36,7 +36,7 @@ extension ObjCOptimization {
 
     /// Relative method list type are offsets from this address
     /// - Parameter cache: DyldCache to which `self` belongs
-    /// - Returns: relative selector's base address
+    /// - Returns: relative type's base address
     public func relativeMethodTypeBaseAddress(
         in cache: DyldCacheLoaded
     ) -> UnsafeRawPointer? {

--- a/Sources/MachOKitC/include/objc.h
+++ b/Sources/MachOKitC/include/objc.h
@@ -15,7 +15,7 @@
 
 struct objc_optimization
 {
-    uint32_t version; // = 1
+    uint32_t version; // = 1-2
     uint32_t flags;
     uint64_t headerInfoROCacheOffset;
     uint64_t headerInfoRWCacheOffset;
@@ -23,6 +23,10 @@ struct objc_optimization
     uint64_t classHashTableCacheOffset;
     uint64_t protocolHashTableCacheOffset;
     uint64_t relativeMethodSelectorBaseAddressOffset;
+
+    // Added in version 2
+    uint64_t relativeMethodSelectorBufferSize;
+    uint64_t relativeMethodTypesBufferSize; // this buffer starts at the end of the selectors buffer
 };
 
 // https://github.com/apple-oss-distributions/dyld/blob/a571176e8e00c47e95b95e3156820ebec0cbd5e6/common/OptimizerObjC.h#L656


### PR DESCRIPTION
- Implemented `relativeMethodTypeBaseAddress` method for calculating offsets from the relative method list address.
- Updated `objc_optimization` struct to reflect version changes and added new fields for buffer sizes.

https://github.com/apple-oss-distributions/dyld/commit/e9da5ae571b4191dcdbcfd827363f19847c84561#diff-679a6b0ff217bdc94aed0f36aaa9e5a5929873540f6d3b74dc4887699200b713