### PR TITLE
fix: resolve cross-subcache pointers in FullDyldCache rebase

### DIFF
--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -264,10 +264,10 @@ extension FullDyldCache {
     ///
     /// [dyld Implementation](https://github.com/apple-oss-distributions/dyld/blob/66c652a1f1f6b7b5266b8bbfd51cb0965d67cc44/common/MetadataVisitor.cpp#L265)
     public func resolveRebase(at offset: UInt64) -> UInt64? {
-        guard let cache = cache(forOffset: offset) else {
+        guard let (cache, localOffset) = cacheAndLocalOffset(forOffset: offset) else {
             return nil
         }
-        return cache.resolveRebase(at: offset)
+        return cache.resolveRebase(at: localOffset)
     }
 
     /// File offset after optional rebasing performed on the specified file offset
@@ -277,10 +277,30 @@ extension FullDyldCache {
     /// [dyld implementation](https://github.com/apple-oss-distributions/dyld/blob/66c652a1f1f6b7b5266b8bbfd51cb0965d67cc44/common/MetadataVisitor.cpp#L435)
     /// `resolveOptionalRebase` differs from `resolveRebase` in that rebasing may or may not actually take place.
     public func resolveOptionalRebase(at offset: UInt64) -> UInt64? {
-        guard let cache = cache(forOffset: offset) else {
+        guard let (cache, localOffset) = cacheAndLocalOffset(forOffset: offset) else {
             return nil
         }
-        return cache.resolveOptionalRebase(at: offset)
+        return cache.resolveOptionalRebase(at: localOffset)
+    }
+
+    /// The subcache that maps `offset`, paired with `offset` translated into
+    /// that subcache's own coordinate space.
+    ///
+    /// `cache(forOffset:)` builds the subcache's `DyldCache` from that file's
+    /// standalone mmap, so its mapping table is addressed from the start of
+    /// the subcache file. `DyldCache.resolveRebase` / `resolveOptionalRebase`
+    /// consult that table via `mappingAndSlideInfo(forFileOffset:)` and read
+    /// bytes through the subcache's own file handle, so they must be given a
+    /// subcache-local offset — the full-cache `offset` minus the subcache's
+    /// start within the full cache. This mirrors the `- segment.offset`
+    /// adjustment already applied in `machOFiles()`; without it the lookup
+    /// always misses for any pointer outside the first subcache.
+    private func cacheAndLocalOffset(forOffset offset: UInt64) -> (DyldCache, UInt64)? {
+        guard let (_, segment) = urlAndFileSegment(forOffset: offset),
+              let cache = cache(forOffset: offset) else {
+            return nil
+        }
+        return (cache, offset - numericCast(segment.offset))
     }
 }
 


### PR DESCRIPTION
## Summary

`FullDyldCache.resolveRebase(_:at:)` / `resolveOptionalRebase(_:at:)` forwarded a cache-global file offset straight to a subcache's `DyldCache`, whose mapping table is addressed from the start of that subcache file. Any pointer that fell outside the first subcache missed `mappingAndSlideInfo(forFileOffset:)` and resolved to `nil`.

## Fix

Add `cacheAndLocalOffset(forOffset:)` to translate a cache-global offset into the owning subcache's own coordinate space (`- segment.offset`) before delegating, mirroring the same adjustment that `machOFiles()` already applies when iterating across subcaches.

## Test plan

- [ ] Rebase resolution returns non-nil pointers for symbols whose backing data lives in non-primary subcaches (e.g. modern `dyld_shared_cache_*` artefacts split into many `.NN` files).
- [ ] Existing primary-subcache rebase resolution still works (regression check).