### PR TITLE
fix: correct dependency type for LC_LOAD_WEAK_DYLIB

### DIFF
--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -197,7 +197,7 @@ extension MachOFile {
                     flags = dylibUseCmd.flags
                 }
                 let lib = cmd.dylib(in: self)
-                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
+                dependencies.append(.init(dylib: lib, type: .weakLoad, useFlags: flags))
             case let .reexportDylib(cmd):
                 let lib = cmd.dylib(in: self)
                 dependencies.append(.init(dylib: lib, type: .reexport))

--- a/Sources/MachOKit/MachOImage.swift
+++ b/Sources/MachOKit/MachOImage.swift
@@ -172,7 +172,7 @@ extension MachOImage {
                     flags = dylibUseCmd.flags
                 }
                 let lib = cmd.dylib(cmdsStart: cmdsStartPtr)
-                dependencies.append(.init(dylib: lib, type: .load, useFlags: flags))
+                dependencies.append(.init(dylib: lib, type: .weakLoad, useFlags: flags))
             case let .reexportDylib(cmd):
                 let lib = cmd.dylib(cmdsStart: cmdsStartPtr)
                 dependencies.append(.init(dylib: lib, type: .reexport))


### PR DESCRIPTION
## Summary

The `.loadWeakDylib` case in both `MachOFile.dependencies` and `MachOImage.dependencies` was producing dependencies with type `.load` instead of `.weakLoad`, causing weakly-linked dylibs to be mis-classified as regular loads.

## Fix

Map `LC_LOAD_WEAK_DYLIB` to `Dylib.UseType.weakLoad` in both `MachOFile.swift` and `MachOImage.swift`, matching the dyld semantics for `LC_LOAD_WEAK_DYLIB`.

## Test plan

- [ ] For a Mach-O binary that contains `LC_LOAD_WEAK_DYLIB` commands, `dependencies` reports the corresponding entries with `useType == .weakLoad`.
- [ ] Other `useType` cases (`.load`, `.reexport`, `.upward`, `.lazyLoad`) remain unchanged.