### PR TITLE
Cache FullDyldCache main and subcache instances

### DIFF
--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -50,6 +50,33 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 
     public var subCacheSuffixes: [String]
 
+    public private(set) lazy var mainCache: DyldCache = {
+        let cache: DyldCache = .init(
+            unsafeFileHandle: fileHandle._files[0]._file,
+            url: url,
+            cpu: cpu,
+            mainCache: nil
+        )
+        cache._fullCache = self
+        cache._symbolCache = _symbolCache
+        return cache
+    }()
+
+    public private(set) lazy var subCaches: [DyldCache] = {
+        let mainCache = self.mainCache
+        return zip(subCacheSuffixes, fileHandle._files[1...])
+            .map {
+                let cache: DyldCache = .init(
+                    unsafeFileHandle: $1._file,
+                    url: .init(string: url.path + $0)!,
+                    cpu: cpu,
+                    mainCache: mainCache
+                )
+                cache._fullCache = self
+                return cache
+            }
+    }()
+
     public init(url: URL) throws {
         self.url = url
 
@@ -88,33 +115,6 @@ extension FullDyldCache {
 }
 
 extension FullDyldCache {
-    public var mainCache: DyldCache {
-        let cache: DyldCache = .init(
-            unsafeFileHandle: fileHandle._files[0]._file,
-            url: url,
-            cpu: cpu,
-            mainCache: nil
-        )
-        cache._fullCache = self
-        cache._symbolCache = _symbolCache
-        return cache
-    }
-
-    public var subCaches: [DyldCache] {
-        let mainCache = self.mainCache
-        return zip(subCacheSuffixes, fileHandle._files[1...])
-            .map {
-                let cache: DyldCache = .init(
-                    unsafeFileHandle: $1._file,
-                    url: .init(string: url.path + $0)!,
-                    cpu: cpu,
-                    mainCache: mainCache
-                )
-                cache._fullCache = self
-                return cache
-            }
-    }
-
     public var allCaches: [DyldCache] {
         [mainCache] + subCaches
     }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -202,11 +202,17 @@ extension FullDyldCache {
     /// DyldCache containing unmapped local symbols
     public var symbolCache: DyldCache? {
         get throws {
-            symbolCacheLock.lock()
-            defer { symbolCacheLock.unlock() }
-            if let _symbolCache { return _symbolCache }
+            let cachedSymbolCache = symbolCacheLock.withLock {
+                _symbolCache
+            }
+            if let cachedSymbolCache { return cachedSymbolCache }
+
             let symbolCache = try mainCache.symbolCache
-            _symbolCache = symbolCache
+
+            symbolCacheLock.withLock {
+                _symbolCache = symbolCache
+            }
+
             return symbolCache
         }
     }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -34,7 +34,16 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
     let fileHandle: File
 
     // Retain the symbol cache
+    private let symbolCacheLock = NSLock()
     private var _symbolCache: DyldCache?
+
+    // Retain the main cache
+    private let mainCacheLock = NSLock()
+    private var _mainCache: DyldCache?
+
+    // Retain the sub caches
+    private let subCachesLock = NSLock()
+    private var _subCaches: [DyldCache]?
 
     public var headerSize: Int {
         header.actualSize
@@ -49,33 +58,6 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
     public let cpu: CPU
 
     public var subCacheSuffixes: [String]
-
-    public private(set) lazy var mainCache: DyldCache = {
-        let cache: DyldCache = .init(
-            unsafeFileHandle: fileHandle._files[0]._file,
-            url: url,
-            cpu: cpu,
-            mainCache: nil
-        )
-        cache._fullCache = self
-        cache._symbolCache = _symbolCache
-        return cache
-    }()
-
-    public private(set) lazy var subCaches: [DyldCache] = {
-        let mainCache = self.mainCache
-        return zip(subCacheSuffixes, fileHandle._files[1...])
-            .map {
-                let cache: DyldCache = .init(
-                    unsafeFileHandle: $1._file,
-                    url: .init(string: url.path + $0)!,
-                    cpu: cpu,
-                    mainCache: mainCache
-                )
-                cache._fullCache = self
-                return cache
-            }
-    }()
 
     public init(url: URL) throws {
         self.url = url
@@ -101,6 +83,49 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 }
 
 extension FullDyldCache {
+    public var mainCache: DyldCache {
+        mainCacheLock.lock()
+        defer { mainCacheLock.unlock() }
+
+        if let _mainCache { return _mainCache }
+
+        let cache: DyldCache = .init(
+            unsafeFileHandle: fileHandle._files[0]._file,
+            url: url,
+            cpu: cpu,
+            mainCache: nil
+        )
+        cache._fullCache = self
+        symbolCacheLock.withLock {
+            cache._symbolCache = _symbolCache
+        }
+        _mainCache = cache
+        return cache
+    }
+
+    public var subCaches: [DyldCache] {
+        let mainCache = self.mainCache
+
+        subCachesLock.lock()
+        defer { subCachesLock.unlock() }
+
+        if let _subCaches { return _subCaches }
+
+        let subCaches = zip(subCacheSuffixes, fileHandle._files[1...])
+            .map {
+                let cache: DyldCache = .init(
+                    unsafeFileHandle: $1._file,
+                    url: .init(string: url.path + $0)!,
+                    cpu: cpu,
+                    mainCache: mainCache
+                )
+                cache._fullCache = self
+                return cache
+            }
+        _subCaches = subCaches
+        return subCaches
+    }
+
     /// Header for main dyld cache
     /// When this dyld cache is a subcache, represent the header of the main cache
     public var mainCacheHeader: DyldCacheHeader { header }
@@ -168,14 +193,16 @@ extension FullDyldCache {
     // Sequence of sub caches
     public typealias SubCaches = DyldCache.SubCaches
     @_implements(DyldCacheRepresentable, subCaches)
-    public var _subCaches: SubCaches? {
+    public var __DyldCacheRepresentable_subCaches: SubCaches? {
         mainCache.subCaches
     }
 
     /// DyldCache containing unmapped local symbols
     public var symbolCache: DyldCache? {
         get throws {
-            if let _symbolCache = _symbolCache { return _symbolCache }
+            symbolCacheLock.lock()
+            defer { symbolCacheLock.unlock() }
+            if let _symbolCache { return _symbolCache }
             let symbolCache = try mainCache.symbolCache
             _symbolCache = symbolCache
             return symbolCache

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -37,13 +37,13 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
     private let symbolCacheLock = NSLock()
     private var _symbolCache: DyldCache?
 
-    // Retain the main cache
+    // Cache the main cache while it is retained by callers or child caches
     private let mainCacheLock = NSLock()
-    private var _mainCache: DyldCache?
+    private weak var _mainCache: DyldCache?
 
-    // Retain the sub caches
+    // Cache the sub caches while they are retained by callers
     private let subCachesLock = NSLock()
-    private var _subCaches: [DyldCache]?
+    private var _subCaches: [WeakBox<DyldCache>]?
 
     public var headerSize: Int {
         header.actualSize
@@ -80,6 +80,12 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
         self.cpu = mainCache.cpu
         self.subCacheSuffixes = subCacheSuffixes
     }
+
+    private func subCacheBoxes() -> [WeakBox<DyldCache>] {
+        if let _subCaches { return _subCaches }
+        return subCacheSuffixes.map { _ in WeakBox(wrapped: nil) }
+    }
+
 }
 
 extension FullDyldCache {
@@ -123,20 +129,25 @@ extension FullDyldCache {
         subCachesLock.lock()
         defer { subCachesLock.unlock() }
 
-        if let _subCaches { return _subCaches }
-
+        let boxes = subCacheBoxes()
         let subCaches = zip(subCacheSuffixes, fileHandle._files[1...])
-            .map {
+            .enumerated()
+            .map { index, element in
+                if let cache = boxes[index].wrapped {
+                    return cache
+                }
+
                 let cache: DyldCache = .init(
-                    unsafeFileHandle: $1._file,
-                    url: .init(fileURLWithPath: url.path + $0),
+                    unsafeFileHandle: element.1._file,
+                    url: .init(fileURLWithPath: url.path + element.0),
                     cpu: cpu,
                     mainCache: mainCache
                 )
                 cache._fullCache = self
+                boxes[index].wrapped = cache
                 return cache
             }
-        _subCaches = subCaches
+        _subCaches = boxes
         return subCaches
     }
 }
@@ -234,7 +245,6 @@ extension FullDyldCache {
     /// Sequence of MachO information contained in this cache
     public func machOFiles() -> AnySequence<MachOFile> {
         guard let imageInfos else { return AnySequence([]) }
-        let mainCache = self.mainCache
         let machOFiles = imageInfos
             .lazy
             .compactMap { info in
@@ -249,13 +259,9 @@ extension FullDyldCache {
                 guard let (url, segment) = self.urlAndFileSegment(forOffset: fileOffset) else {
                     return nil
                 }
-                let cache: DyldCache = .init(
-                    unsafeFileHandle: segment._file,
-                    url: url,
-                    cpu: self.cpu,
-                    mainCache: segment.offset == 0 ? nil : mainCache
-                )
-                cache._fullCache = self
+                guard let cache = self.cache(forOffset: fileOffset) else {
+                    return nil
+                }
 
                 return try? .init(
                     url: url,
@@ -275,13 +281,9 @@ extension FullDyldCache {
         guard let (url, segment) = self.urlAndFileSegment(forOffset: fileOffset) else {
             return nil
         }
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: self.cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
-        )
-        cache._fullCache = self
+        guard let cache = cache(forOffset: fileOffset) else {
+            return nil
+        }
 
         return try? MachOFile(
             url: url,
@@ -321,15 +323,16 @@ extension FullDyldCache {
     /// The subcache that maps `offset`, paired with `offset` translated into
     /// that subcache's own coordinate space.
     ///
-    /// `cache(forOffset:)` builds the subcache's `DyldCache` from that file's
-    /// standalone mmap, so its mapping table is addressed from the start of
-    /// the subcache file. `DyldCache.resolveRebase` / `resolveOptionalRebase`
-    /// consult that table via `mappingAndSlideInfo(forFileOffset:)` and read
-    /// bytes through the subcache's own file handle, so they must be given a
-    /// subcache-local offset — the full-cache `offset` minus the subcache's
-    /// start within the full cache. This mirrors the `- segment.offset`
-    /// adjustment already applied in `machOFiles()`; without it the lookup
-    /// always misses for any pointer outside the first subcache.
+    /// `cache(forOffset:)` returns the subcache's `DyldCache` backed by that
+    /// file's standalone mmap, so its mapping table is addressed from the start
+    /// of the subcache file. `DyldCache.resolveRebase` /
+    /// `resolveOptionalRebase` consult that table via
+    /// `mappingAndSlideInfo(forFileOffset:)` and read bytes through the
+    /// subcache's own file handle, so they must be given a subcache-local
+    /// offset — the full-cache `offset` minus the subcache's start within the
+    /// full cache. This mirrors the `- segment.offset` adjustment already
+    /// applied in `machOFiles()`; without it the lookup always misses for any
+    /// pointer outside the first subcache.
     private func cacheAndLocalOffset(forOffset offset: UInt64) -> (DyldCache, UInt64)? {
         guard let (_, segment) = urlAndFileSegment(forOffset: offset),
               let cache = cache(forOffset: offset) else {
@@ -372,29 +375,28 @@ extension FullDyldCache {
     }
 
     public func cache(forOffset offset: UInt64) -> DyldCache? {
-        guard let (url, segment) = urlAndFileSegment(forOffset: offset) else {
+        guard let index = fileHandle._files.firstIndex(
+            where: {
+                $0.offset <= offset && offset < $0.offset + $0.size
+            }
+        ) else {
             return nil
         }
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
-        )
-        cache._fullCache = self
-        return cache
+        return cache(at: index)
     }
 
     public func cache(for url: URL) -> DyldCache? {
         guard let index = urls.firstIndex(of: url) else { return nil }
-        let segment = fileHandle._files[index]
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
-        )
-        cache._fullCache = self
-        return cache
+        return cache(at: index)
+    }
+
+    private func cache(at index: Int) -> DyldCache? {
+        guard fileHandle._files.indices.contains(index) else {
+            return nil
+        }
+        if index == 0 {
+            return mainCache
+        }
+        return subCaches[index - 1]
     }
 }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -129,7 +129,7 @@ extension FullDyldCache {
             .map {
                 let cache: DyldCache = .init(
                     unsafeFileHandle: $1._file,
-                    url: .init(string: url.path + $0)!,
+                    url: .init(fileURLWithPath: url.path + $0),
                     cpu: cpu,
                     mainCache: mainCache
                 )

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -83,6 +83,20 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 }
 
 extension FullDyldCache {
+    /// Header for main dyld cache
+    /// When this dyld cache is a subcache, represent the header of the main cache
+    public var mainCacheHeader: DyldCacheHeader { header }
+}
+
+extension FullDyldCache {
+    public var urls: [URL] {
+        [url] + subCacheSuffixes.map {
+            URL(fileURLWithPath: url.path + $0)
+        }
+    }
+}
+
+extension FullDyldCache {
     public var mainCache: DyldCache {
         mainCacheLock.lock()
         defer { mainCacheLock.unlock() }
@@ -124,18 +138,6 @@ extension FullDyldCache {
             }
         _subCaches = subCaches
         return subCaches
-    }
-
-    /// Header for main dyld cache
-    /// When this dyld cache is a subcache, represent the header of the main cache
-    public var mainCacheHeader: DyldCacheHeader { header }
-}
-
-extension FullDyldCache {
-    public var urls: [URL] {
-        [url] + subCacheSuffixes.map {
-            URL(fileURLWithPath: url.path + $0)
-        }
     }
 }
 

--- a/Sources/MachOKit/Util/WeakBox.swift
+++ b/Sources/MachOKit/Util/WeakBox.swift
@@ -1,0 +1,15 @@
+//
+//  WeakBox.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2026/06/11
+//
+//
+
+final class WeakBox<T: AnyObject> {
+    weak var wrapped: T?
+
+    init(wrapped: T?) {
+        self.wrapped = wrapped
+    }
+}


### PR DESCRIPTION
## Summary

- Cache `FullDyldCache.mainCache` as a lazy stored property
- Cache `FullDyldCache.subCaches` as a lazy stored property
- Avoid recreating `DyldCache` wrappers on repeated access to `mainCache`, `subCaches`, or `allCaches`

## Motivation

`FullDyldCache.mainCache` and `subCaches` previously rebuilt `DyldCache` objects
every time they were accessed. This adds unnecessary overhead for workflows that
repeatedly inspect a full dyld cache or traverse `allCaches`.

By making these values lazy, the cache wrappers are initialized once and reused
for subsequent accesses while preserving the existing public API shape.