### PR TITLE
perf: preload subcache headers in FullDyldCache to avoid repeated header reads

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -125,12 +125,15 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
         unsafeFileHandle fileHandle: File,
         url: URL,
         cpu: CPU,
+        header: DyldCacheHeader? = nil,
         mainCache: DyldCache? = nil
     ) {
         self.fileHandle = fileHandle
         self.url = url
-        self.header = try! fileHandle.read(
-            offset: 0
+        self.header = header ?? (
+            try! fileHandle.read(
+                offset: 0
+            )
         )
         self.cpu = cpu
         self._mainCache = mainCache

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -119,24 +119,6 @@ extension FullDyldCache {
     public var allCaches: [DyldCache] {
         [mainCache] + subCaches
     }
-
-    /// Assemble the `DyldCache` for the file at `index` from the
-    /// preloaded header, without re-reading it from the file
-    internal func cache(
-        atIndex index: Int,
-        mainCache: DyldCache? = nil
-    ) -> DyldCache {
-        if index == 0 { return mainCache ?? self.mainCache }
-        let cache: DyldCache = .init(
-            unsafeFileHandle: fileHandle._files[index]._file,
-            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1]),
-            cpu: cpu,
-            header: subCacheHeaders[index - 1],
-            mainCache: mainCache ?? self.mainCache
-        )
-        cache._fullCache = self
-        return cache
-    }
 }
 
 extension FullDyldCache {
@@ -354,5 +336,25 @@ extension FullDyldCache {
     public func cache(for url: URL) -> DyldCache? {
         guard let index = urls.firstIndex(of: url) else { return nil }
         return cache(atIndex: index)
+    }
+}
+
+extension FullDyldCache {
+    /// Assemble the `DyldCache` for the file at `index` from the
+    /// preloaded header, without re-reading it from the file
+    internal func cache(
+        atIndex index: Int,
+        mainCache: DyldCache? = nil
+    ) -> DyldCache {
+        if index == 0 { return mainCache ?? self.mainCache }
+        let cache: DyldCache = .init(
+            unsafeFileHandle: fileHandle._files[index]._file,
+            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1]),
+            cpu: cpu,
+            header: subCacheHeaders[index - 1],
+            mainCache: mainCache ?? self.mainCache
+        )
+        cache._fullCache = self
+        return cache
     }
 }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -50,6 +50,10 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 
     public var subCacheSuffixes: [String]
 
+    // Headers of sub caches, preloaded to avoid re-reading them
+    // every time a `DyldCache` is assembled
+    internal let subCacheHeaders: [DyldCacheHeader]
+
     public init(url: URL) throws {
         self.url = url
 
@@ -63,13 +67,17 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
             URL(fileURLWithPath: url.path + $0)
         }
 
-        self.fileHandle = try .open(
+        let fileHandle: File = try .open(
             urls: urls,
             isWritable: false
         )
+        self.fileHandle = fileHandle
         self.header = mainCache.header
         self.cpu = mainCache.cpu
         self.subCacheSuffixes = subCacheSuffixes
+        self.subCacheHeaders = try fileHandle._files[1...].map {
+            try $0._file.read(offset: 0)
+        }
     }
 }
 
@@ -93,6 +101,7 @@ extension FullDyldCache {
             unsafeFileHandle: fileHandle._files[0]._file,
             url: url,
             cpu: cpu,
+            header: header,
             mainCache: nil
         )
         cache._fullCache = self
@@ -102,21 +111,31 @@ extension FullDyldCache {
 
     public var subCaches: [DyldCache] {
         let mainCache = self.mainCache
-        return zip(subCacheSuffixes, fileHandle._files[1...])
-            .map {
-                let cache: DyldCache = .init(
-                    unsafeFileHandle: $1._file,
-                    url: .init(string: url.path + $0)!,
-                    cpu: cpu,
-                    mainCache: mainCache
-                )
-                cache._fullCache = self
-                return cache
-            }
+        return (1..<fileHandle._files.count).map {
+            cache(atIndex: $0, mainCache: mainCache)
+        }
     }
 
     public var allCaches: [DyldCache] {
         [mainCache] + subCaches
+    }
+
+    /// Assemble the `DyldCache` for the file at `index` from the
+    /// preloaded header, without re-reading it from the file
+    internal func cache(
+        atIndex index: Int,
+        mainCache: DyldCache? = nil
+    ) -> DyldCache {
+        if index == 0 { return mainCache ?? self.mainCache }
+        let cache: DyldCache = .init(
+            unsafeFileHandle: fileHandle._files[index]._file,
+            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1]),
+            cpu: cpu,
+            header: subCacheHeaders[index - 1],
+            mainCache: mainCache ?? self.mainCache
+        )
+        cache._fullCache = self
+        return cache
     }
 }
 
@@ -211,19 +230,13 @@ extension FullDyldCache {
             }
             .compactMap { (imagePath: String, fileOffset: UInt64) ->
                 MachOFile? in
-                guard let (url, segment) = self.urlAndFileSegment(forOffset: fileOffset) else {
+                guard let index = self.fileIndex(forOffset: fileOffset) else {
                     return nil
                 }
-                let cache: DyldCache = .init(
-                    unsafeFileHandle: segment._file,
-                    url: url,
-                    cpu: self.cpu,
-                    mainCache: segment.offset == 0 ? nil : mainCache
-                )
-                cache._fullCache = self
-
+                let cache = self.cache(atIndex: index, mainCache: mainCache)
+                let segment = self.fileHandle._files[index]
                 return try? .init(
-                    url: url,
+                    url: cache.url,
                     imagePath: imagePath,
                     headerStartOffsetInCache: numericCast(fileOffset) - segment.offset,
                     cache: cache
@@ -237,19 +250,11 @@ extension FullDyldCache {
         guard let fileOffset = fileOffset(of: header.dyldInCacheMH) else {
             return nil
         }
-        guard let (url, segment) = self.urlAndFileSegment(forOffset: fileOffset) else {
+        guard let (cache, segment) = cacheAndFileSegment(forOffset: fileOffset) else {
             return nil
         }
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: self.cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
-        )
-        cache._fullCache = self
-
         return try? MachOFile(
-            url: url,
+            url: cache.url,
             imagePath: "/usr/lib/dyld",
             headerStartOffsetInCache: numericCast(fileOffset) - segment.offset,
             cache: cache
@@ -296,8 +301,7 @@ extension FullDyldCache {
     /// adjustment already applied in `machOFiles()`; without it the lookup
     /// always misses for any pointer outside the first subcache.
     private func cacheAndLocalOffset(forOffset offset: UInt64) -> (DyldCache, UInt64)? {
-        guard let (_, segment) = urlAndFileSegment(forOffset: offset),
-              let cache = cache(forOffset: offset) else {
+        guard let (cache, segment) = cacheAndFileSegment(forOffset: offset) else {
             return nil
         }
         return (cache, offset - numericCast(segment.offset))
@@ -306,11 +310,7 @@ extension FullDyldCache {
 
 extension FullDyldCache {
     public func url(forOffset offset: UInt64) -> URL? {
-        guard let index = fileHandle._files.firstIndex(
-            where: {
-                $0.offset <= offset && offset < $0.offset + $0.size
-            }
-        ) else { return nil }
+        guard let index = fileIndex(forOffset: offset) else { return nil }
         if index == 0 { return url }
         return .init(
             fileURLWithPath: url.path + subCacheSuffixes[index - 1]
@@ -322,44 +322,31 @@ extension FullDyldCache {
     }
 
     internal func urlAndFileSegment(forOffset offset: UInt64) -> (URL, File.FileSegment)? {
-        guard let index = fileHandle._files.firstIndex(
-            where: {
-                $0.offset <= offset && offset < $0.offset + $0.size
-            }
-        ) else { return nil }
-        if index == 0 {
-            return (url, fileHandle._files[0])
-        }
-        let url: URL = .init(
-            fileURLWithPath: url.path + subCacheSuffixes[index - 1]
-        )
+        guard let index = fileIndex(forOffset: offset),
+              let url = url(forOffset: offset) else { return nil }
         return (url, fileHandle._files[index])
     }
 
-    public func cache(forOffset offset: UInt64) -> DyldCache? {
-        guard let (url, segment) = urlAndFileSegment(forOffset: offset) else {
-            return nil
-        }
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
+    internal func cacheAndFileSegment(forOffset offset: UInt64) -> (DyldCache, File.FileSegment)? {
+        guard let index = fileIndex(forOffset: offset) else { return nil }
+        return (cache(atIndex: index), fileHandle._files[index])
+    }
+
+    private func fileIndex(forOffset offset: UInt64) -> Int? {
+        fileHandle._files.firstIndex(
+            where: {
+                $0.offset <= offset && offset < $0.offset + $0.size
+            }
         )
-        cache._fullCache = self
-        return cache
+    }
+
+    public func cache(forOffset offset: UInt64) -> DyldCache? {
+        guard let index = fileIndex(forOffset: offset) else { return nil }
+        return cache(atIndex: index)
     }
 
     public func cache(for url: URL) -> DyldCache? {
         guard let index = urls.firstIndex(of: url) else { return nil }
-        let segment = fileHandle._files[index]
-        let cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cpu,
-            mainCache: segment.offset == 0 ? nil : mainCache
-        )
-        cache._fullCache = self
-        return cache
+        return cache(atIndex: index)
     }
 }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -322,8 +322,14 @@ extension FullDyldCache {
     }
 
     internal func urlAndFileSegment(forOffset offset: UInt64) -> (URL, File.FileSegment)? {
-        guard let index = fileIndex(forOffset: offset),
-              let url = url(forOffset: offset) else { return nil }
+        guard let index = fileIndex(forOffset: offset) else { return nil }
+        let url: URL = if index == 0 {
+            url
+        } else {
+            .init(
+                fileURLWithPath: url.path + subCacheSuffixes[index - 1]
+            )
+        }
         return (url, fileHandle._files[index])
     }
 

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
@@ -154,21 +154,13 @@ extension ObjCHeaderInfoRO64 {
         in cache: FullDyldCache
     ) -> MachOFile? {
         guard let offset = resolvedMachOHeaderOffset(in: cache),
-              let (url, segment) = cache.urlAndFileSegment(forOffset: offset) else {
+              let (_cache, segment) = cache.cacheAndFileSegment(forOffset: offset) else {
             return nil
         }
         let imagePath = imagePath(in: cache)
 
-        let _cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cache.cpu,
-            mainCache: segment.offset == 0 ? nil : cache.mainCache
-        )
-        _cache._fullCache = cache
-
         return try? .init(
-            url: url,
+            url: _cache.url,
             imagePath: imagePath,
             headerStartOffsetInCache: numericCast(offset) - segment.offset,
             cache: _cache
@@ -270,21 +262,13 @@ extension ObjCHeaderInfoRO32 {
         in cache: FullDyldCache
     ) -> MachOFile? {
         guard let offset = resolvedMachOHeaderOffset(in: cache),
-              let (url, segment) = cache.urlAndFileSegment(forOffset: offset) else {
+              let (_cache, segment) = cache.cacheAndFileSegment(forOffset: offset) else {
             return nil
         }
         let imagePath = imagePath(in: cache)
 
-        let _cache: DyldCache = .init(
-            unsafeFileHandle: segment._file,
-            url: url,
-            cpu: cache.cpu,
-            mainCache: segment.offset == 0 ? nil : cache.mainCache
-        )
-        _cache._fullCache = cache
-
         return try? .init(
-            url: url,
+            url: _cache.url,
             imagePath: imagePath,
             headerStartOffsetInCache: numericCast(offset) - segment.offset,
             cache: _cache


### PR DESCRIPTION
## Problem

Every access to `FullDyldCache.mainCache`, `subCaches`, `cache(forOffset:)`,
`machOFiles()`, `dyld`, and `ObjCHeaderInfoRO.machO(in:)` constructed a fresh
`DyldCache` through `init(unsafeFileHandle:)`, which performs a header read
from the file on every call. For workloads that touch these APIs repeatedly
(e.g. iterating all images in the cache), this resulted in a large number of
redundant header reads and noticeably poor performance.

## Solution

- `FullDyldCache` reads each subcache header exactly once at init and keeps
  them in a new internal `subCacheHeaders` property. The main cache header was
  already stored as `header`.
- `DyldCache.init(unsafeFileHandle:)` gains an optional `header:` parameter;
  when a preloaded header is supplied, the init skips reading it from the file
  (passing `nil` preserves the previous behavior).
- A new internal `cache(atIndex:mainCache:)` helper assembles a `DyldCache`
  from the preloaded header, and is now used by `cache(forOffset:)`,
  `cache(for:)`, `cacheAndFileSegment(forOffset:)`, `machOFiles()`, `dyld`,
  and `ObjCHeaderInfoRO._machO(in:)`. `machOFiles()` keeps assembling a single
  `mainCache` shared across the whole sequence, as before.

`FullDyldCache` intentionally does not retain the assembled `DyldCache`
instances — only the headers — so there is no retain cycle and the existing
semantics (computed properties returning fresh instances) are unchanged.

Also unifies subcache URL construction on `URL(fileURLWithPath:)`;
`subCaches` previously built scheme-less URLs via `URL(string:)`, while other
APIs such as `urls` and `url(forOffset:)` already used file URLs.

## Public API

No changes. `mainCache` / `subCaches` remain computed properties with the same
signatures and semantics.

## Validation

- `swift build` passes
- `FullDyldCachePrintTests` (all 22 tests, run against the host dyld shared
  cache) pass
- Verified locally that assembled subcaches report the same header (UUID) as
  the preloaded ones, that `FullDyldCache` deallocates without leaks, and that
  10,000 accesses of `mainCache` + `subCaches` (~30 subcaches) complete in
  ~80ms — pure object assembly with no file I/O per access