### PR TITLE
Improve dyld cache URL construction performance

### DIFF
--- a/Sources/MachOKit/DyldCache+host.swift
+++ b/Sources/MachOKit/DyldCache+host.swift
@@ -6,7 +6,7 @@ extension DyldCache {
         guard let path = _DyldSharedCacheRuntime.sharedCacheFilePath() else {
             return nil
         }
-        let url: URL = .init(fileURLWithPath: path)
+        let url: URL = .init(fileURLWithPath: path, isDirectory: false)
         return try? DyldCache(url: url)
         #else
         return nil

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -250,7 +250,7 @@ extension DyldCache {
             let suffix = ".symbols"
             let path = url.path + suffix
             let symbolCache: DyldCache = try .init(
-                subcacheUrl: .init(fileURLWithPath: path),
+                subcacheUrl: .init(fileURLWithPath: path, isDirectory: false),
                 mainCacheHeader: mainCacheHeader
             )
             _symbolCache = symbolCache

--- a/Sources/MachOKit/FullDyldCache+host.swift
+++ b/Sources/MachOKit/FullDyldCache+host.swift
@@ -14,7 +14,7 @@ extension FullDyldCache {
         guard let path = _DyldSharedCacheRuntime.sharedCacheFilePath() else {
             return nil
         }
-        let url: URL = .init(fileURLWithPath: path)
+        let url: URL = .init(fileURLWithPath: path, isDirectory: false)
         return try? FullDyldCache(url: url)
 #else
         return nil

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -50,6 +50,9 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 
     public var subCacheSuffixes: [String]
 
+    /// URLs of the main cache file and all its subcache files
+    public let urls: [URL]
+
     // Headers of sub caches, preloaded to avoid re-reading them
     // every time a `DyldCache` is assembled
     internal let subCacheHeaders: [DyldCacheHeader]
@@ -78,6 +81,7 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
         self.subCacheHeaders = try fileHandle._files[1...].map {
             try $0._file.read(offset: 0)
         }
+        self.urls = urls
     }
 }
 
@@ -85,14 +89,6 @@ extension FullDyldCache {
     /// Header for main dyld cache
     /// When this dyld cache is a subcache, represent the header of the main cache
     public var mainCacheHeader: DyldCacheHeader { header }
-}
-
-extension FullDyldCache {
-    public var urls: [URL] {
-        [url] + subCacheSuffixes.map {
-            URL(fileURLWithPath: url.path + $0, isDirectory: false)
-        }
-    }
 }
 
 extension FullDyldCache {
@@ -293,11 +289,7 @@ extension FullDyldCache {
 extension FullDyldCache {
     public func url(forOffset offset: UInt64) -> URL? {
         guard let index = fileIndex(forOffset: offset) else { return nil }
-        if index == 0 { return url }
-        return .init(
-            fileURLWithPath: url.path + subCacheSuffixes[index - 1],
-            isDirectory: false
-        )
+        return urls[index]
     }
 
     internal func fileSegment(forOffset offset: UInt64) -> File.FileSegment? {
@@ -306,15 +298,7 @@ extension FullDyldCache {
 
     internal func urlAndFileSegment(forOffset offset: UInt64) -> (URL, File.FileSegment)? {
         guard let index = fileIndex(forOffset: offset) else { return nil }
-        let url: URL = if index == 0 {
-            url
-        } else {
-            .init(
-                fileURLWithPath: url.path + subCacheSuffixes[index - 1],
-                isDirectory: false
-            )
-        }
-        return (url, fileHandle._files[index])
+        return (urls[index], fileHandle._files[index])
     }
 
     internal func cacheAndFileSegment(forOffset offset: UInt64) -> (DyldCache, File.FileSegment)? {
@@ -351,7 +335,7 @@ extension FullDyldCache {
         if index == 0 { return mainCache ?? self.mainCache }
         let cache: DyldCache = .init(
             unsafeFileHandle: fileHandle._files[index]._file,
-            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1], isDirectory: false),
+            url: urls[index],
             cpu: cpu,
             header: subCacheHeaders[index - 1],
             mainCache: mainCache ?? self.mainCache

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -64,7 +64,7 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
         } ?? []
         var urls = [url]
         urls += subCacheSuffixes.map {
-            URL(fileURLWithPath: url.path + $0)
+            URL(fileURLWithPath: url.path + $0, isDirectory: false)
         }
 
         let fileHandle: File = try .open(
@@ -90,7 +90,7 @@ extension FullDyldCache {
 extension FullDyldCache {
     public var urls: [URL] {
         [url] + subCacheSuffixes.map {
-            URL(fileURLWithPath: url.path + $0)
+            URL(fileURLWithPath: url.path + $0, isDirectory: false)
         }
     }
 }
@@ -295,7 +295,8 @@ extension FullDyldCache {
         guard let index = fileIndex(forOffset: offset) else { return nil }
         if index == 0 { return url }
         return .init(
-            fileURLWithPath: url.path + subCacheSuffixes[index - 1]
+            fileURLWithPath: url.path + subCacheSuffixes[index - 1],
+            isDirectory: false
         )
     }
 
@@ -309,7 +310,8 @@ extension FullDyldCache {
             url
         } else {
             .init(
-                fileURLWithPath: url.path + subCacheSuffixes[index - 1]
+                fileURLWithPath: url.path + subCacheSuffixes[index - 1],
+                isDirectory: false
             )
         }
         return (url, fileHandle._files[index])
@@ -349,7 +351,7 @@ extension FullDyldCache {
         if index == 0 { return mainCache ?? self.mainCache }
         let cache: DyldCache = .init(
             unsafeFileHandle: fileHandle._files[index]._file,
-            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1]),
+            url: URL(fileURLWithPath: url.path + subCacheSuffixes[index - 1], isDirectory: false),
             cpu: cpu,
             header: subCacheHeaders[index - 1],
             mainCache: mainCache ?? self.mainCache

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -48,7 +48,7 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
     /// It is obtained based on magic.
     public let cpu: CPU
 
-    public var subCacheSuffixes: [String]
+    public let subCacheSuffixes: [String]
 
     /// URLs of the main cache file and all its subcache files
     public let urls: [URL]

--- a/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldSubCacheEntry.swift
@@ -70,7 +70,7 @@ extension DyldSubCacheEntry {
                 }
             )
         }
-        let url = URL(fileURLWithPath: cache.url.path + fileSuffix)
+        let url = URL(fileURLWithPath: cache.url.path + fileSuffix, isDirectory: false)
         let subcache = try DyldCache(subcacheUrl: url, mainCache: cache)
         subcache._fullCache = cache._fullCache
         return subcache


### PR DESCRIPTION
## Summary

- Pass `isDirectory: false` when constructing file URLs from dyld cache paths.
- Store `FullDyldCache.urls` instead of recreating subcache URLs on each access.
- Make `subCacheSuffixes` immutable after initialization.

## Motivation

Foundation may perform extra filesystem I/O when constructing file URLs without directory hints. Dyld cache loading creates and reuses URLs for the main cache, subcaches, and symbol cache files, so these paths should be treated explicitly as files.

This follows Apple's guidance to provide directory hints for file URLs:
https://developer.apple.com/documentation/foundation/improving-performance-and-stability-when-accessing-the-file-system#Provide-directory-hints-for-file-URLs-to-avoid-wasteful-IO

## Validation

- `swift build`