### PR TITLE
Add benchmark infrastructure for performance work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ DerivedData/
 XCFrameworks/
 docs/
 symbol-graphs/
+
+Benchmarks/.benchmarkBaselines/
+Benchmarks/.build/
+Benchmarks/.swiftpm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ For dyld cache work:
   dyld cache paths.
 - For parser or binary-layout changes, prefer stable fixtures or small
   synthetic data over new tests that depend on `/System/Applications`.
+- For performance changes, verify the impact with
+  `make benchmark-baseline-compare` whenever a benchmark baseline is available.
 - For Markdown-only changes, a build is not normally required.
 
 ## Do Not Drift

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/Benchmarks.swift
@@ -1,0 +1,6 @@
+let benchmarks: @Sendable () -> Void = {
+    registerMachOFileBenchmarks()
+    registerRebaseBindBenchmarks()
+    registerDyldCacheBenchmarks()
+    registerFullDyldCacheBenchmarks()
+}

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/DyldCacheBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/DyldCacheBenchmarks.swift
@@ -1,0 +1,81 @@
+import Benchmark
+import Foundation
+import MachOKit
+
+func registerDyldCacheBenchmarks() {
+    guard BenchmarkFixtures.hasDyldCache else { return }
+
+    Benchmark("DyldCache.machOFiles.enumerate") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        for machO in cache.machOFiles() {
+            blackHole(machO)
+            count += 1
+        }
+        blackHole(count)
+    }
+
+    Benchmark("DyldCache.fileOffset.translate") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+        let addresses = BenchmarkFixtures.dyldCacheAddresses(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(cache.fileOffset(of: address))
+        }
+    }
+
+    Benchmark("DyldCache.address.translate") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.address(of: fileOffset))
+        }
+    }
+
+    Benchmark("DyldCache.mappingInfo.lookup") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+        let addresses = BenchmarkFixtures.dyldCacheAddresses(from: cache, limit: 100_000)
+        let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(cache.mappingInfo(for: address))
+            blackHole(cache.mappingAndSlideInfo(for: address))
+        }
+        for fileOffset in fileOffsets {
+            blackHole(cache.mappingInfo(forFileOffset: fileOffset))
+            blackHole(cache.mappingAndSlideInfo(forFileOffset: fileOffset))
+        }
+    }
+
+    Benchmark("DyldCache.resolveRebase") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCachePointerFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.resolveRebase(at: fileOffset))
+        }
+    }
+
+    Benchmark("DyldCache.resolveOptionalRebase") { benchmark in
+        guard let cache = BenchmarkFixtures.dyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCachePointerFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.resolveOptionalRebase(at: fileOffset))
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
@@ -21,6 +21,30 @@ enum BenchmarkFixtures {
         return URL(fileURLWithPath: path)
     }
 
+    static var fullDyldCacheURL: URL? {
+        guard let path = ProcessInfo.processInfo.environment["MACHOKIT_BENCH_FULL_DYLD_CACHE"],
+              !path.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: path)
+    }
+
+    static var hasDyldCache: Bool {
+        #if canImport(Darwin)
+        true
+        #else
+        dyldCacheURL != nil
+        #endif
+    }
+
+    static var hasFullDyldCache: Bool {
+        #if canImport(Darwin)
+        true
+        #else
+        fullDyldCacheURL != nil
+        #endif
+    }
+
     static func machOFile() -> MachOFile {
         do {
             return try MachOFile(url: machOURL)
@@ -30,11 +54,24 @@ enum BenchmarkFixtures {
     }
 
     static func dyldCache() -> DyldCache? {
-        guard let dyldCacheURL else { return nil }
+        guard let dyldCacheURL else {
+            return DyldCache.host
+        }
         do {
             return try DyldCache(url: dyldCacheURL)
         } catch {
             fatalError("Failed to load dyld cache benchmark fixture at \(dyldCacheURL.path): \(error)")
+        }
+    }
+
+    static func fullDyldCache() -> FullDyldCache? {
+        guard let fullDyldCacheURL else {
+            return FullDyldCache.host
+        }
+        do {
+            return try FullDyldCache(url: fullDyldCacheURL)
+        } catch {
+            fatalError("Failed to load full dyld cache benchmark fixture at \(fullDyldCacheURL.path): \(error)")
         }
     }
 
@@ -49,5 +86,111 @@ enum BenchmarkFixtures {
 
     static func symbolName(from machO: MachOFile) -> String? {
         machO.symbols.first?.name
+    }
+
+    static func exportedSymbolNames(from machO: MachOFile, limit: Int) -> [String] {
+        guard let exportTrie = machO.exportTrie else {
+            return []
+        }
+        return Array(
+            exportTrie.exportedSymbols.lazy
+                .map(\.name)
+                .filter { !$0.isEmpty }
+                .prefix(limit)
+        )
+    }
+
+    static func exportedSymbolPrefixes(from machO: MachOFile, limit: Int) -> [String] {
+        let prefixes = exportedSymbolNames(from: machO, limit: limit)
+            .map { String($0.prefix(8)) }
+            .filter { !$0.isEmpty }
+        return prefixes.isEmpty ? [] : prefixes
+    }
+
+    static func machOAddresses(from machO: MachOFile, limit: Int) -> [UInt64] {
+        let addresses = machO.segments.lazy.flatMap { segment in
+            stride(
+                from: 0,
+                to: max(segment.virtualMemorySize, 1),
+                by: max(segment.virtualMemorySize / 64, 1)
+            )
+            .lazy
+            .map { UInt64(segment.virtualMemoryAddress + $0) }
+        }
+        let result = Array(addresses.prefix(limit))
+        return result.isEmpty ? [0] : result
+    }
+
+    static func dyldCacheAddresses(from cache: some DyldCacheRepresentable, limit: Int) -> [UInt64] {
+        guard let mapping = cache.mappingInfos?.first,
+              mapping.size > 0 else {
+            return []
+        }
+        return (0..<limit).map {
+            mapping.address + UInt64($0) % mapping.size
+        }
+    }
+
+    static func dyldCacheFileOffsets(from cache: some DyldCacheRepresentable, limit: Int) -> [UInt64] {
+        guard let mapping = cache.mappingInfos?.first,
+              mapping.size > 0 else {
+            return []
+        }
+        return (0..<limit).map {
+            mapping.fileOffset + UInt64($0) % mapping.size
+        }
+    }
+
+    static func dyldCacheFileOffsetsAcrossMappings(
+        from cache: some DyldCacheRepresentable,
+        limit: Int
+    ) -> [UInt64] {
+        guard let mappings = cache.mappingInfos,
+              !mappings.isEmpty else {
+            return []
+        }
+
+        return (0..<limit).compactMap { index in
+            let mapping = mappings[mappings.index(mappings.startIndex, offsetBy: index % mappings.count)]
+            guard mapping.size > 0 else {
+                return nil
+            }
+            return mapping.fileOffset + UInt64(index) % mapping.size
+        }
+    }
+
+    static func dyldCachePointerFileOffsets(from cache: some DyldCacheRepresentable, limit: Int) -> [UInt64] {
+        guard let mapping = cache.mappingInfos?.first else {
+            return []
+        }
+
+        let pointerSize: UInt64 = cache.cpu.is64Bit ? 8 : 4
+        guard mapping.size >= pointerSize else {
+            return []
+        }
+
+        let pointerCount = max(mapping.size / pointerSize, 1)
+        return (0..<limit).map {
+            mapping.fileOffset + (UInt64($0) % pointerCount) * pointerSize
+        }
+    }
+
+    static func chainedFixupPointers(
+        from machO: MachOFile,
+        limit: Int
+    ) -> [DyldChainedFixupPointer] {
+        guard let chainedFixups = machO.dyldChainedFixups,
+              let startsInImage = chainedFixups.startsInImage else {
+            return []
+        }
+
+        var pointers: [DyldChainedFixupPointer] = []
+        for segment in chainedFixups.startsInSegments(of: startsInImage) {
+            pointers += chainedFixups.pointers(of: segment, in: machO)
+            if pointers.count >= limit {
+                return Array(pointers.prefix(limit))
+            }
+        }
+        return pointers
     }
 }

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
@@ -1,0 +1,53 @@
+import Foundation
+import MachOKit
+
+enum BenchmarkFixtures {
+    static var machOURL: URL {
+        if let path = ProcessInfo.processInfo.environment["MACHOKIT_BENCH_MACHO"],
+           !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+        if let executableURL = Bundle.main.executableURL {
+            return executableURL
+        }
+        return URL(fileURLWithPath: CommandLine.arguments[0])
+    }
+
+    static var dyldCacheURL: URL? {
+        guard let path = ProcessInfo.processInfo.environment["MACHOKIT_BENCH_DYLD_CACHE"],
+              !path.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: path)
+    }
+
+    static func machOFile() -> MachOFile {
+        do {
+            return try MachOFile(url: machOURL)
+        } catch {
+            fatalError("Failed to load Mach-O benchmark fixture at \(machOURL.path): \(error)")
+        }
+    }
+
+    static func dyldCache() -> DyldCache? {
+        guard let dyldCacheURL else { return nil }
+        do {
+            return try DyldCache(url: dyldCacheURL)
+        } catch {
+            fatalError("Failed to load dyld cache benchmark fixture at \(dyldCacheURL.path): \(error)")
+        }
+    }
+
+    static func symbolOffsets(from machO: MachOFile, limit: Int) -> [Int] {
+        let offsets = machO.symbols.lazy
+            .map(\.offset)
+            .filter { $0 >= 0 }
+            .prefix(limit)
+        let result = Array(offsets)
+        return result.isEmpty ? [0] : result
+    }
+
+    static func symbolName(from machO: MachOFile) -> String? {
+        machO.symbols.first?.name
+    }
+}

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/FullDyldCacheBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/FullDyldCacheBenchmarks.swift
@@ -1,0 +1,93 @@
+import Benchmark
+import Foundation
+import MachOKit
+
+func registerFullDyldCacheBenchmarks() {
+    guard BenchmarkFixtures.hasFullDyldCache else { return }
+
+    Benchmark("FullDyldCache.machOFiles.enumerate") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        for machO in cache.machOFiles() {
+            blackHole(machO)
+            count += 1
+        }
+        blackHole(count)
+    }
+
+    Benchmark("FullDyldCache.fileOffset.translate") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let addresses = BenchmarkFixtures.dyldCacheAddresses(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(cache.fileOffset(of: address))
+        }
+    }
+
+    Benchmark("FullDyldCache.mappingInfo.lookup") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let addresses = BenchmarkFixtures.dyldCacheAddresses(from: cache, limit: 100_000)
+        let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(cache.mappingInfo(for: address))
+            blackHole(cache.mappingAndSlideInfo(for: address))
+        }
+        for fileOffset in fileOffsets {
+            blackHole(cache.mappingInfo(forFileOffset: fileOffset))
+            blackHole(cache.mappingAndSlideInfo(forFileOffset: fileOffset))
+        }
+    }
+
+    Benchmark("FullDyldCache.cache.forOffset") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsetsAcrossMappings(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.cache(forOffset: fileOffset))
+        }
+    }
+
+    Benchmark("FullDyldCache.cache.forURL") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let urls = cache.urls
+        let iterations = 100_000
+
+        benchmark.startMeasurement()
+
+        for index in 0..<iterations {
+            blackHole(cache.cache(for: urls[index % urls.count]))
+        }
+    }
+
+    Benchmark("FullDyldCache.resolveRebase") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCachePointerFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.resolveRebase(at: fileOffset))
+        }
+    }
+
+    Benchmark("FullDyldCache.resolveOptionalRebase") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let fileOffsets = BenchmarkFixtures.dyldCachePointerFileOffsets(from: cache, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for fileOffset in fileOffsets {
+            blackHole(cache.resolveOptionalRebase(at: fileOffset))
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/MachOFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/MachOFileBenchmarks.swift
@@ -1,0 +1,113 @@
+import Benchmark
+import Foundation
+import MachOKit
+
+let benchmarks: @Sendable () -> Void = {
+    Benchmark("MachOFile.symbols.enumerate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        for symbol in machO.symbols {
+            blackHole(symbol)
+            count += 1
+        }
+        blackHole(count)
+    }
+
+    Benchmark("MachOFile.exportedSymbols.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.exportedSymbols)
+        }
+    }
+
+    Benchmark("MachOFile.segments.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 1_000
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.segments)
+        }
+    }
+
+    Benchmark("MachOFile.rebases.segmentLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let rebases = machO.rebases
+
+        benchmark.startMeasurement()
+
+        if machO.is64Bit {
+            for rebase in rebases {
+                blackHole(rebase.segment64(in: machO))
+            }
+        } else {
+            for rebase in rebases {
+                blackHole(rebase.segment32(in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.closestSymbol.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let offsets = BenchmarkFixtures.symbolOffsets(from: machO, limit: 1_000)
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(machO.closestSymbol(at: offset))
+        }
+    }
+
+    Benchmark("MachOFile.symbols.named") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let name = BenchmarkFixtures.symbolName(from: machO) ?? "__machokit_missing_symbol__"
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.symbols(named: name))
+            blackHole(machO.symbols(named: name, mangled: false))
+        }
+    }
+
+    if BenchmarkFixtures.dyldCacheURL != nil {
+        Benchmark("DyldCache.machOFiles.enumerate") { benchmark in
+            guard let cache = BenchmarkFixtures.dyldCache() else { return }
+
+            benchmark.startMeasurement()
+
+            var count = 0
+            for machO in cache.machOFiles() {
+                blackHole(machO)
+                count += 1
+            }
+            blackHole(count)
+        }
+
+        Benchmark("DyldCache.fileOffset.translate") { benchmark in
+            guard let cache = BenchmarkFixtures.dyldCache(),
+                  let mappings = cache.mappingInfos,
+                  let firstMapping = mappings.first else {
+                return
+            }
+            let addresses = (0..<100_000).map {
+                firstMapping.address + UInt64($0) % firstMapping.size
+            }
+
+            benchmark.startMeasurement()
+
+            for address in addresses {
+                blackHole(cache.fileOffset(of: address))
+            }
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/MachOFileBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/MachOFileBenchmarks.swift
@@ -2,7 +2,23 @@ import Benchmark
 import Foundation
 import MachOKit
 
-let benchmarks: @Sendable () -> Void = {
+func registerMachOFileBenchmarks() {
+    Benchmark("MachOFile.loadCommands.enumerate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            var count = 0
+            for command in machO.loadCommands {
+                blackHole(command)
+                count += 1
+            }
+            blackHole(count)
+        }
+    }
+
     Benchmark("MachOFile.symbols.enumerate") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
 
@@ -16,6 +32,17 @@ let benchmarks: @Sendable () -> Void = {
         blackHole(count)
     }
 
+    Benchmark("MachOFile.dependencies.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 1_000
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.dependencies)
+        }
+    }
+
     Benchmark("MachOFile.exportedSymbols.repeated") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
         let iterations = 100
@@ -24,6 +51,44 @@ let benchmarks: @Sendable () -> Void = {
 
         for _ in 0..<iterations {
             blackHole(machO.exportedSymbols)
+        }
+    }
+
+    Benchmark("MachOFile.exportTrie.search") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        guard let exportTrie = machO.exportTrie else { return }
+        let names = BenchmarkFixtures.exportedSymbolNames(from: machO, limit: 1_000)
+        guard !names.isEmpty else { return }
+
+        benchmark.startMeasurement()
+
+        for name in names {
+            blackHole(exportTrie.search(by: name))
+        }
+    }
+
+    Benchmark("MachOFile.exportTrie.prefixSearch") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        guard let exportTrie = machO.exportTrie else { return }
+        let prefixes = BenchmarkFixtures.exportedSymbolPrefixes(from: machO, limit: 100)
+        guard !prefixes.isEmpty else { return }
+
+        benchmark.startMeasurement()
+
+        for prefix in prefixes {
+            blackHole(exportTrie.search(byKeyPrefix: prefix))
+        }
+    }
+
+    Benchmark("MachOFile.exportTrie.entries") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        guard let exportTrie = machO.exportTrie else { return }
+        let iterations = 10
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(exportTrie.entries)
         }
     }
 
@@ -38,21 +103,41 @@ let benchmarks: @Sendable () -> Void = {
         }
     }
 
-    Benchmark("MachOFile.rebases.segmentLookup") { benchmark in
+    Benchmark("MachOFile.sections.repeated") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let rebases = machO.rebases
+        let iterations = 1_000
 
         benchmark.startMeasurement()
 
-        if machO.is64Bit {
-            for rebase in rebases {
-                blackHole(rebase.segment64(in: machO))
-            }
-        } else {
-            for rebase in rebases {
-                blackHole(rebase.segment32(in: machO))
+        for _ in 0..<iterations {
+            blackHole(machO.sections)
+        }
+    }
+
+    Benchmark("MachOFile.allCStringTables.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.allCStringTables)
+        }
+    }
+
+    Benchmark("MachOFile.functionStarts.enumerate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        if let functionStarts = machO.functionStarts {
+            for functionStart in functionStarts {
+                blackHole(functionStart)
+                count += 1
             }
         }
+        blackHole(count)
     }
 
     Benchmark("MachOFile.closestSymbol.repeated") { benchmark in
@@ -79,35 +164,26 @@ let benchmarks: @Sendable () -> Void = {
         }
     }
 
-    if BenchmarkFixtures.dyldCacheURL != nil {
-        Benchmark("DyldCache.machOFiles.enumerate") { benchmark in
-            guard let cache = BenchmarkFixtures.dyldCache() else { return }
+    Benchmark("MachOFile.fileOffset.translate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let addresses = BenchmarkFixtures.machOAddresses(from: machO, limit: 100_000)
 
-            benchmark.startMeasurement()
+        benchmark.startMeasurement()
 
-            var count = 0
-            for machO in cache.machOFiles() {
-                blackHole(machO)
-                count += 1
-            }
-            blackHole(count)
-        }
-
-        Benchmark("DyldCache.fileOffset.translate") { benchmark in
-            guard let cache = BenchmarkFixtures.dyldCache(),
-                  let mappings = cache.mappingInfos,
-                  let firstMapping = mappings.first else {
-                return
-            }
-            let addresses = (0..<100_000).map {
-                firstMapping.address + UInt64($0) % firstMapping.size
-            }
-
-            benchmark.startMeasurement()
-
-            for address in addresses {
-                blackHole(cache.fileOffset(of: address))
-            }
+        for address in addresses {
+            blackHole(machO.fileOffset(of: address))
         }
     }
+
+    Benchmark("MachOFile.contains.unslidAddress") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let addresses = BenchmarkFixtures.machOAddresses(from: machO, limit: 100_000)
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(machO.contains(unslidAddress: address))
+        }
+    }
+
 }

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/RebaseBindBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/RebaseBindBenchmarks.swift
@@ -1,0 +1,259 @@
+import Benchmark
+import Foundation
+import MachOKit
+
+func registerRebaseBindBenchmarks() {
+    Benchmark("MachOFile.rebaseOperations.enumerate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let operations = machO.rebaseOperations
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        if let operations {
+            for operation in operations {
+                blackHole(operation)
+                count += 1
+            }
+        }
+        blackHole(count)
+    }
+
+    Benchmark("MachOFile.bindOperations.enumerate") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let operations = [
+            machO.bindOperations,
+            machO.weakBindOperations,
+            machO.lazyBindOperations,
+        ]
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        for operations in operations {
+            guard let operations else { continue }
+            for operation in operations {
+                blackHole(operation)
+                count += 1
+            }
+        }
+        blackHole(count)
+    }
+
+    Benchmark("MachOFile.rebases.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.rebases)
+        }
+    }
+
+    Benchmark("MachOFile.bindings.repeated") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let iterations = 100
+
+        benchmark.startMeasurement()
+
+        for _ in 0..<iterations {
+            blackHole(machO.bindingSymbols)
+            blackHole(machO.weakBindingSymbols)
+            blackHole(machO.lazyBindingSymbols)
+        }
+    }
+
+    Benchmark("MachOFile.rebases.segmentLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let rebases = machO.rebases
+
+        benchmark.startMeasurement()
+
+        if machO.is64Bit {
+            for rebase in rebases {
+                blackHole(rebase.segment64(in: machO))
+            }
+        } else {
+            for rebase in rebases {
+                blackHole(rebase.segment32(in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.rebases.sectionLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let rebases = machO.rebases
+
+        benchmark.startMeasurement()
+
+        if machO.is64Bit {
+            for rebase in rebases {
+                blackHole(rebase.section64(in: machO))
+            }
+        } else {
+            for rebase in rebases {
+                blackHole(rebase.section32(in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.rebases.address") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let rebases = machO.rebases
+
+        benchmark.startMeasurement()
+
+        for rebase in rebases {
+            blackHole(rebase.address(in: machO))
+        }
+    }
+
+    Benchmark("MachOFile.bindings.segmentLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+
+        benchmark.startMeasurement()
+
+        if machO.is64Bit {
+            for binding in bindings {
+                blackHole(binding.segment64(in: machO))
+            }
+        } else {
+            for binding in bindings {
+                blackHole(binding.segment32(in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.bindings.sectionLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+
+        benchmark.startMeasurement()
+
+        if machO.is64Bit {
+            for binding in bindings {
+                blackHole(binding.section64(in: machO))
+            }
+        } else {
+            for binding in bindings {
+                blackHole(binding.section32(in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.bindings.libraryLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+
+        benchmark.startMeasurement()
+
+        for binding in bindings {
+            blackHole(binding.library(in: machO))
+        }
+    }
+
+    Benchmark("MachOFile.bindings.address") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+
+        benchmark.startMeasurement()
+
+        for binding in bindings {
+            blackHole(binding.address(in: machO))
+        }
+    }
+
+    Benchmark("MachOFile.dyldChainedFixups.metadata") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let chainedFixups = machO.dyldChainedFixups
+
+        benchmark.startMeasurement()
+
+        guard let chainedFixups else { return }
+        blackHole(chainedFixups.header)
+        blackHole(chainedFixups.startsInImage)
+        if let startsInImage = chainedFixups.startsInImage {
+            let startsInSegments = chainedFixups.startsInSegments(of: startsInImage)
+            blackHole(startsInSegments)
+            for segment in startsInSegments {
+                blackHole(chainedFixups.pages(of: segment))
+            }
+        }
+        blackHole(chainedFixups.imports)
+    }
+
+    Benchmark("MachOFile.dyldChainedFixups.pointers") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let chainedFixups = machO.dyldChainedFixups
+        let startsInImage = chainedFixups?.startsInImage
+        let startsInSegments = chainedFixups?.startsInSegments(of: startsInImage) ?? []
+
+        benchmark.startMeasurement()
+
+        var count = 0
+        if let chainedFixups {
+            for segment in startsInSegments {
+                let pointers = chainedFixups.pointers(of: segment, in: machO)
+                count += pointers.count
+                blackHole(pointers)
+            }
+        }
+        blackHole(count)
+    }
+
+    Benchmark("MachOFile.dyldChainedFixups.pointerLookup") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let chainedFixups = machO.dyldChainedFixups
+        let offsets = BenchmarkFixtures.chainedFixupPointers(from: machO, limit: 1_000)
+            .map { UInt64($0.offset) }
+
+        benchmark.startMeasurement()
+
+        if let chainedFixups {
+            for offset in offsets {
+                blackHole(chainedFixups.pointer(for: offset, in: machO))
+            }
+        }
+    }
+
+    Benchmark("MachOFile.resolveRebase") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let offsets = BenchmarkFixtures.chainedFixupPointers(from: machO, limit: 1_000)
+            .filter { $0.fixupInfo.rebase != nil }
+            .map { UInt64($0.offset) }
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(machO.resolveRebase(at: offset))
+        }
+    }
+
+    Benchmark("MachOFile.resolveOptionalRebase") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let offsets = BenchmarkFixtures.chainedFixupPointers(from: machO, limit: 1_000)
+            .filter { $0.fixupInfo.rebase != nil }
+            .map { UInt64($0.offset) }
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(machO.resolveOptionalRebase(at: offset))
+        }
+    }
+
+    Benchmark("MachOFile.resolveBind") { benchmark in
+        let machO = BenchmarkFixtures.machOFile()
+        let offsets = BenchmarkFixtures.chainedFixupPointers(from: machO, limit: 1_000)
+            .filter { $0.fixupInfo.bind != nil }
+            .map { UInt64($0.offset) }
+
+        benchmark.startMeasurement()
+
+        for offset in offsets {
+            blackHole(machO.resolveBind(at: offset))
+        }
+    }
+}

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,0 +1,132 @@
+{
+  "originHash" : "9d162019d83de672b529fac25408abb2a163cbaf28ef5c847c5292585d600a41",
+  "pins" : [
+    {
+      "identity" : "benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/benchmark",
+      "state" : {
+        "revision" : "595d8db7d9d612ecf256ebf659c20aeec338c5ca",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "hdrhistogram-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
+      "state" : {
+        "revision" : "c2e1210df04b4fff47e53f2f9dad9cc45ae15d63",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "objectarchivekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/ObjectArchiveKit.git",
+      "state" : {
+        "revision" : "96d782a576273b73b277b577943a2a25b00b919e",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "package-jemalloc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-jemalloc.git",
+      "state" : {
+        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-binary-parse-support",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/swift-binary-parse-support.git",
+      "state" : {
+        "revision" : "5fb96b503672ea4752eded6b4e301fd87214b03b",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-fileio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/swift-fileio.git",
+      "state" : {
+        "revision" : "d589ff3966f9f064574780f527449a946736b989",
+        "version" : "0.13.0"
+      }
+    },
+    {
+      "identity" : "swift-fileio-extra",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/swift-fileio-extra.git",
+      "state" : {
+        "revision" : "8d83506dd4dff737807d90dbf2264096ed98c7a7",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "texttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/TextTable.git",
+      "state" : {
+        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "MachOKitBenchmarks",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.4.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MachOKitBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "MachOKit", package: "MachOKit"),
+            ],
+            path: "Benchmarks/MachOKitBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "benchmark")
+            ]
+        )
+    ]
+)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+# Build artifacts
+
 .PHONY: xcframework
 xcframework:
 	bash scripts/xcframework.sh
+
+# Documentation
 
 .PHONY: docc
 docc:
@@ -9,3 +13,35 @@ docc:
 .PHONY: docc-preview
 docc-preview:
 	bash scripts/docc-preview.sh
+
+# Benchmarks
+#
+# Usage:
+#   make benchmark
+#   make benchmark BENCHMARK_ARGS='--filter MachOFile.exportTrie.search'
+#   make benchmark-baseline-update BASELINE=main
+
+BENCHMARK_DIR := Benchmarks
+BENCHMARK_ENV ?= BENCHMARK_DISABLE_JEMALLOC=1
+BENCHMARK_ARGS ?=
+BASELINE ?= main
+
+.PHONY: benchmark-build
+benchmark-build:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift build
+
+.PHONY: benchmark-list
+benchmark-list:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark list
+
+.PHONY: benchmark
+benchmark:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark $(BENCHMARK_ARGS)
+
+.PHONY: benchmark-baseline-update
+benchmark-baseline-update:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package --allow-writing-to-package-directory benchmark baseline update $(BASELINE) $(BENCHMARK_ARGS)
+
+.PHONY: benchmark-baseline-compare
+benchmark-baseline-compare:
+	cd $(BENCHMARK_DIR) && $(BENCHMARK_ENV) swift package benchmark baseline compare $(BASELINE) $(BENCHMARK_ARGS)


### PR DESCRIPTION
## Summary

- Add a standalone `Benchmarks` SwiftPM package using `ordo-one/benchmark`
- Add benchmark coverage for Mach-O parsing, symbols, export tries, rebase/bind paths, chained fixups, and dyld cache APIs
- Add Makefile targets for building, listing, running, and comparing benchmark baselines
- Ignore local benchmark build/cache/baseline artifacts
- Document benchmark baseline comparison as the validation path for performance changes

## Validation

- `make benchmark-build`
- `make benchmark-list`
- `make benchmark BENCHMARK_ARGS='--filter MachOFile.exportTrie.search'`