### PR TITLE
Reuse dyld cache file handles when enumerating Mach-O files

### DIFF
--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -86,10 +86,11 @@ public class MachOFile: MachORepresentable {
         try self.init(
             url: url,
             imagePath: imagePath,
+            fileHandle: cache.fileHandle,
             headerStartOffset: 0,
-            headerStartOffsetInCache: headerStartOffsetInCache
+            headerStartOffsetInCache: headerStartOffsetInCache,
+            cache: cache
         )
-        self._cache = cache
     }
 
     @available(*, deprecated, renamed: "init(url:imagePath:headerStartOffsetInCache:cache:)")
@@ -106,19 +107,37 @@ public class MachOFile: MachORepresentable {
         )
     }
 
-    package init(
+    package convenience init(
         url: URL,
         imagePath: String?,
         headerStartOffset: Int,
         headerStartOffsetInCache: Int
     ) throws {
-        self.url = url
-        self._imagePath = imagePath
         let fileHandle = try File.open(
             url: url,
             isWritable: false
         )
+        try self.init(
+            url: url,
+            imagePath: imagePath,
+            fileHandle: fileHandle,
+            headerStartOffset: headerStartOffset,
+            headerStartOffsetInCache: headerStartOffsetInCache
+        )
+    }
+
+    private init(
+        url: URL,
+        imagePath: String?,
+        fileHandle: File,
+        headerStartOffset: Int,
+        headerStartOffsetInCache: Int,
+        cache: DyldCache? = nil
+    ) throws {
+        self.url = url
+        self._imagePath = imagePath
         self.fileHandle = fileHandle
+        self._cache = cache
 
         self.headerStartOffset = headerStartOffset
         self.headerStartOffsetInCache = headerStartOffsetInCache


### PR DESCRIPTION
## Summary

- Reuses the existing `DyldCache` file handle when creating `MachOFile` instances from dyld cache entries
- Avoids repeatedly opening and memory-mapping the same dyld cache file during `machOFiles()` enumeration
- Keeps the public initializer shape unchanged while routing cache-backed construction through a shared internal initializer

## Performance

`DyldCache.machOFiles.enumerate`:

- Wall clock p50: `36ms -> 4ms`
- Instructions p50: `568M -> 62M`

`FullDyldCache.machOFiles.enumerate`:

- Wall clock p50: `92ms -> 11ms`
- Instructions p50: `1493M -> 183M`

## Validation

- `swift build`
- `BENCHMARK_DISABLE_JEMALLOC=1 swift package benchmark baseline compare main --filter '^DyldCache\.machOFiles\.enumerate$' --metric wallClock --metric instructions --no-progress --scale --time-units milliseconds`
- `BENCHMARK_DISABLE_JEMALLOC=1 swift package benchmark baseline compare main --filter '^FullDyldCache\.machOFiles\.enumerate$' --metric wallClock --metric instructions --no-progress --scale --time-units milliseconds`