### PR TITLE
Optimize classic rebase and bind segment lookup

### DIFF
--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
@@ -1,3 +1,4 @@
+import Benchmark
 import Foundation
 import MachOKit
 
@@ -51,6 +52,34 @@ enum BenchmarkFixtures {
         } catch {
             fatalError("Failed to load Mach-O benchmark fixture at \(machOURL.path): \(error)")
         }
+    }
+
+    static func classicRebases(from machO: MachOFile, benchmark: Benchmark) -> [Rebase]? {
+        let rebases = machO.rebases
+        guard !rebases.isEmpty else {
+            benchmark.error(
+                """
+                Mach-O benchmark fixture has no classic dyld rebase opcodes: \(machO.url.path).
+                Set MACHOKIT_BENCH_MACHO to a thin Mach-O with LC_DYLD_INFO_ONLY rebase data.
+                """
+            )
+            return nil
+        }
+        return rebases
+    }
+
+    static func classicBindings(from machO: MachOFile, benchmark: Benchmark) -> [BindingSymbol]? {
+        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+        guard !bindings.isEmpty else {
+            benchmark.error(
+                """
+                Mach-O benchmark fixture has no classic dyld bind opcodes: \(machO.url.path).
+                Set MACHOKIT_BENCH_MACHO to a thin Mach-O with LC_DYLD_INFO_ONLY bind data.
+                """
+            )
+            return nil
+        }
+        return bindings
     }
 
     static func dyldCache() -> DyldCache? {

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/RebaseBindBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/RebaseBindBenchmarks.swift
@@ -42,6 +42,10 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.rebases.repeated") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
+        guard let rebases = BenchmarkFixtures.classicRebases(from: machO, benchmark: benchmark) else {
+            return
+        }
+        blackHole(rebases)
         let iterations = 100
 
         benchmark.startMeasurement()
@@ -53,6 +57,10 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.bindings.repeated") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
+        guard let bindings = BenchmarkFixtures.classicBindings(from: machO, benchmark: benchmark) else {
+            return
+        }
+        blackHole(bindings)
         let iterations = 100
 
         benchmark.startMeasurement()
@@ -66,7 +74,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.rebases.segmentLookup") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let rebases = machO.rebases
+        guard let rebases = BenchmarkFixtures.classicRebases(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -83,7 +93,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.rebases.sectionLookup") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let rebases = machO.rebases
+        guard let rebases = BenchmarkFixtures.classicRebases(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -100,7 +112,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.rebases.address") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let rebases = machO.rebases
+        guard let rebases = BenchmarkFixtures.classicRebases(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -111,7 +125,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.bindings.segmentLookup") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+        guard let bindings = BenchmarkFixtures.classicBindings(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -128,7 +144,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.bindings.sectionLookup") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+        guard let bindings = BenchmarkFixtures.classicBindings(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -145,7 +163,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.bindings.libraryLookup") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+        guard let bindings = BenchmarkFixtures.classicBindings(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 
@@ -156,7 +176,9 @@ func registerRebaseBindBenchmarks() {
 
     Benchmark("MachOFile.bindings.address") { benchmark in
         let machO = BenchmarkFixtures.machOFile()
-        let bindings = machO.bindingSymbols + machO.weakBindingSymbols + machO.lazyBindingSymbols
+        guard let bindings = BenchmarkFixtures.classicBindings(from: machO, benchmark: benchmark) else {
+            return
+        }
 
         benchmark.startMeasurement()
 

--- a/Sources/MachOKit/Extension/Sequence+.swift
+++ b/Sources/MachOKit/Extension/Sequence+.swift
@@ -8,6 +8,21 @@
 
 import Foundation
 
+extension Sequence {
+    func element(at index: Int) -> Element? {
+        guard index >= 0 else { return nil }
+        var iterator = makeIterator()
+        var currentIndex = 0
+        while let element = iterator.next() {
+            if currentIndex == index {
+                return element
+            }
+            currentIndex += 1
+        }
+        return nil
+    }
+}
+
 // https://opensource.apple.com/source/ld64/ld64-253.9/src/other/dyldinfo.cpp.auto.html
 extension Sequence<BindOperation> {
     func bindings(

--- a/Sources/MachOKit/Model/BindingSymbol.swift
+++ b/Sources/MachOKit/Model/BindingSymbol.swift
@@ -56,31 +56,23 @@ extension BindingSymbol {
 
 extension BindingSymbol {
     public func segment64(in machO: MachOImage) -> SegmentCommand64? {
-        let segments = Array(machO.segments64)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments64.element(at: index)
     }
 
     public func segment32(in machO: MachOImage) -> SegmentCommand? {
-        let segments = Array(machO.segments32)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments32.element(at: index)
     }
 
     public func segment64(in machO: MachOFile) -> SegmentCommand64? {
-        let segments = Array(machO.segments64)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments64.element(at: index)
     }
 
     public func segment32(in machO: MachOFile) -> SegmentCommand? {
-        let segments = Array(machO.segments32)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments32.element(at: index)
     }
 }
 

--- a/Sources/MachOKit/Model/Rebase.swift
+++ b/Sources/MachOKit/Model/Rebase.swift
@@ -16,31 +16,23 @@ public struct Rebase: Sendable {
 
 extension Rebase {
     public func segment64(in machO: MachOImage) -> SegmentCommand64? {
-        let segments = Array(machO.segments64)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments64.element(at: index)
     }
 
     public func segment32(in machO: MachOImage) -> SegmentCommand? {
-        let segments = Array(machO.segments32)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments32.element(at: index)
     }
 
     public func segment64(in machO: MachOFile) -> SegmentCommand64? {
-        let segments = Array(machO.segments64)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments64.element(at: index)
     }
 
     public func segment32(in machO: MachOFile) -> SegmentCommand? {
-        let segments = Array(machO.segments32)
         let index = Int(segmentIndex)
-        guard segments.indices.contains(index) else { return nil }
-        return segments[index]
+        return machO.segments32.element(at: index)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add fixture validation for classic dyld rebase/bind benchmarks so empty chained-fixups-only binaries are reported explicitly.
- Avoid materializing segment arrays when resolving `Rebase` and `BindingSymbol` segment lookups.
- Reuse the lighter segment lookup path for section/address lookup paths that call through those segment helpers.

## Why

The default benchmark executable uses `LC_DYLD_CHAINED_FIXUPS`, so the classic rebase/bind benchmark paths can otherwise run against empty data. After switching to a thin x86_64 `/bin/ls` fixture with `LC_DYLD_INFO_ONLY`, the existing implementation showed that each lookup was allocating an array from `machO.segments32/64` before indexing it.

## Benchmark

Fixture:

```sh
MACHOKIT_BENCH_MACHO=/tmp/machokit-ls-x86_64
```

Command:

```sh
make benchmark-baseline-compare BASELINE=classic-rebase-bind \
  BENCHMARK_ENV='BENCHMARK_DISABLE_JEMALLOC=1 MACHOKIT_BENCH_MACHO=/tmp/machokit-ls-x86_64' \
  BENCHMARK_ARGS='--filter "MachOFile\\.(rebases|bindings)\\.(segmentLookup|sectionLookup)" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'
```

Representative p50 results:

| Benchmark | Wall clock | Instructions |
| --- | ---: | ---: |
| `MachOFile.bindings.segmentLookup` | `396us -> 115us` | `8053K -> 2435K` |
| `MachOFile.bindings.sectionLookup` | `416us -> 151us` | `8585K -> 3162K` |
| `MachOFile.rebases.segmentLookup` | `436us -> 132us` | `9241K -> 2769K` |
| `MachOFile.rebases.sectionLookup` | `474us -> 172us` | `10K -> 4K` |

## Validation

- `swift build`
- Benchmark comparison above

Note: the local working tree still has unrelated unstaged files; only the two commits on this branch are included in this PR.