### PR TITLE
Optimize closest symbol lookup

### DIFF
--- a/Sources/MachOKit/MachOFile+Symbols.swift
+++ b/Sources/MachOKit/MachOFile+Symbols.swift
@@ -364,3 +364,61 @@ extension MachOFile.Symbols: Collection {
 // MARK: - RandomAccessCollection
 extension MachOFile.Symbols64: RandomAccessCollection {}
 extension MachOFile.Symbols: RandomAccessCollection {}
+
+// MARK: - _SymbolTableProtocol
+
+extension MachOFile.Symbols64: _SymbolTableProtocol {
+    func wrappedNlist(at position: Int) -> Nlist64 {
+        var symbol: nlist_64 = try! symbolsSlice.read(
+            offset: Nlist64.layoutSize * position
+        )
+        if isSwapped {
+            swap_nlist_64(&symbol, 1, NXHostByteOrder())
+        }
+        return Nlist64(layout: symbol)
+    }
+
+    func offset(of nlist: Nlist64) -> Int {
+        numericCast(nlist.layout.n_value)
+    }
+
+    func symbol(at position: Int, nlist: Nlist64) -> MachOFile.Symbol {
+        let string = stringsSlice.readString(
+            offset: numericCast(nlist.layout.n_un.n_strx)
+        ) ?? ""
+
+        return .init(
+            name: string,
+            offset: numericCast(nlist.layout.n_value),
+            nlist: nlist
+        )
+    }
+}
+
+extension MachOFile.Symbols: _SymbolTableProtocol {
+    func wrappedNlist(at position: Int) -> Nlist {
+        var symbol: nlist = try! symbolsSlice.read(
+            offset: Nlist.layoutSize * position
+        )
+        if isSwapped {
+            swap_nlist(&symbol, 1, NXHostByteOrder())
+        }
+        return Nlist(layout: symbol)
+    }
+
+    func offset(of nlist: Nlist) -> Int {
+        numericCast(nlist.layout.n_value)
+    }
+
+    func symbol(at position: Int, nlist: Nlist) -> MachOFile.Symbol {
+        let string = stringsSlice.readString(
+            offset: numericCast(nlist.layout.n_un.n_strx)
+        ) ?? ""
+
+        return .init(
+            name: string,
+            offset: numericCast(nlist.layout.n_value),
+            nlist: nlist
+        )
+    }
+}

--- a/Sources/MachOKit/MachOImage+Symbols.swift
+++ b/Sources/MachOKit/MachOImage+Symbols.swift
@@ -283,3 +283,49 @@ extension MachOImage.Symbols: Collection {
 // MARK: - RandomAccessCollection
 extension MachOImage.Symbols64: RandomAccessCollection {}
 extension MachOImage.Symbols: RandomAccessCollection {}
+
+// MARK: - _SymbolTableProtocol
+
+extension MachOImage.Symbols64: _SymbolTableProtocol {
+    func wrappedNlist(at position: Int) -> Nlist64 {
+        Nlist64(layout: symbols.advanced(by: position).pointee)
+    }
+
+    func offset(of nlist: Nlist64) -> Int {
+        addressStart + numericCast(nlist.layout.n_value)
+    }
+
+    func symbol(at position: Int, nlist: Nlist64) -> MachOImage.Symbol {
+        let str = stringBase
+            .advanced(by: numericCast(nlist.layout.n_un.n_strx))
+        let address = addressStart + numericCast(nlist.layout.n_value)
+
+        return MachOImage.Symbol(
+            nameC: str,
+            offset: address,
+            nlist: nlist
+        )
+    }
+}
+
+extension MachOImage.Symbols: _SymbolTableProtocol {
+    func wrappedNlist(at position: Int) -> Nlist {
+        Nlist(layout: symbols.advanced(by: position).pointee)
+    }
+
+    func offset(of nlist: Nlist) -> Int {
+        addressStart + numericCast(nlist.layout.n_value)
+    }
+
+    func symbol(at position: Int, nlist: Nlist) -> MachOImage.Symbol {
+        let str = stringBase
+            .advanced(by: numericCast(nlist.layout.n_un.n_strx))
+        let address = addressStart + numericCast(nlist.layout.n_value)
+
+        return MachOImage.Symbol(
+            nameC: str,
+            offset: address,
+            nlist: nlist
+        )
+    }
+}

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -377,81 +377,140 @@ extension MachORepresentable {
     }
 }
 
-extension MachORepresentable {
-    // ref: https://github.com/apple-oss-distributions/dyld/blob/93bd81f9d7fcf004fcebcb66ec78983882b41e71/common/MachOLoaded.cpp#L606
+extension MachORepresentable where Self == MachOFile {
     public func closestSymbol( // swiftlint:disable:this cyclomatic_complexity
         at offset: Int,
         inSection sectionNumber: Int = 0,
         isGlobalOnly: Bool = false
     ) -> Symbol? {
-        let symbols = Array(self.symbols)
-        var bestSymbol: Symbol?
-
-        if let dysym = loadCommands.dysymtab {
-            // find closest match in globals
-            let globalStart: Int = numericCast(dysym.iextdefsym)
-            let globalCount: Int = numericCast(dysym.nextdefsym)
-            for i in globalStart ..< globalStart + globalCount {
-                let symbol = symbols[i]
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-
-                guard nlist.flags?.type == .sect,
-                      symbol.offset <= offset,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                if let bestSymbol,
-                   bestSymbol.offset >= symbol.offset {
-                    continue
-                }
-                bestSymbol = symbol
-            }
-            if isGlobalOnly { return bestSymbol }
-
-            // find closest match in locals
-            let localStart: Int = numericCast(dysym.ilocalsym)
-            let localCount: Int = numericCast(dysym.nlocalsym)
-            for i in localStart ..< localStart + localCount {
-                let symbol = symbols[i]
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-
-                guard nlist.flags?.type == .sect,
-                      nlist.flags?.stab == nil,
-                      symbol.offset <= offset,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                if let bestSymbol,
-                   bestSymbol.offset >= symbol.offset {
-                    continue
-                }
-                bestSymbol = symbol
-            }
-        } else {
-            // find closest match in locals
-            for symbol in symbols {
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-                guard nlist.flags?.type == .sect,
-                      nlist.flags?.stab == nil,
-                      symbol.offset <= offset,
-                      !isGlobalOnly || nlist.flags?.contains(.ext) ?? false,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                if let bestSymbol,
-                   bestSymbol.offset >= symbol.offset {
-                    continue
-                }
-                bestSymbol = symbol
-            }
+        if is64Bit, let symbols64 {
+            return _closestSymbol(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols64
+            )
+        } else if let symbols32 {
+            return _closestSymbol(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols32
+            )
         }
-
-        return bestSymbol
+        return nil
     }
 
+}
+
+extension MachORepresentable where Self == MachOImage {
+    public func closestSymbol( // swiftlint:disable:this cyclomatic_complexity
+        at offset: Int,
+        inSection sectionNumber: Int = 0,
+        isGlobalOnly: Bool = false
+    ) -> Symbol? {
+        if is64Bit, let symbols64 {
+            return _closestSymbol(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols64
+            )
+        } else if let symbols32 {
+            return _closestSymbol(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols32
+            )
+        }
+        return nil
+    }
+
+}
+
+// ref: https://github.com/apple-oss-distributions/dyld/blob/93bd81f9d7fcf004fcebcb66ec78983882b41e71/common/MachOLoaded.cpp#L606
+@inline(__always)
+private func _closestSymbol<MachO, Table>( // swiftlint:disable:this cyclomatic_complexity
+    in machO: MachO,
+    at offset: Int,
+    inSection sectionNumber: Int,
+    isGlobalOnly: Bool,
+    symbols: Table
+) -> MachO.Symbol? where MachO: MachORepresentable, Table: _SymbolTableProtocol<MachO.Symbol> {
+    var bestIndex: Int?
+    var bestOffset: Int?
+
+    func updateBestSymbol(
+        at index: Int,
+        nlist: Table.WrappedNlist,
+        requireNonStab: Bool,
+        requireExternal: Bool
+    ) {
+        let flags = nlist.flags ?? .init(rawValue: 0)
+        let symbolOffset = symbols.offset(of: nlist)
+
+        guard flags.type == .sect,
+              !requireNonStab || flags.stab == nil,
+              symbolOffset <= offset,
+              !requireExternal || flags.contains(.ext),
+              sectionNumber == 0 || nlist.sectionNumber == sectionNumber else {
+            return
+        }
+        if let bestOffset,
+           bestOffset >= symbolOffset {
+            return
+        }
+        bestIndex = index
+        bestOffset = symbolOffset
+    }
+
+    if let dysym = machO.loadCommands.dysymtab {
+        let globalStart: Int = numericCast(dysym.iextdefsym)
+        let globalCount: Int = numericCast(dysym.nextdefsym)
+        for i in globalStart ..< globalStart + globalCount {
+            updateBestSymbol(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: false,
+                requireExternal: false
+            )
+        }
+        if isGlobalOnly {
+            guard let bestIndex else { return nil }
+            return symbols.symbol(at: bestIndex, nlist: symbols.wrappedNlist(at: bestIndex))
+        }
+
+        let localStart: Int = numericCast(dysym.ilocalsym)
+        let localCount: Int = numericCast(dysym.nlocalsym)
+        for i in localStart ..< localStart + localCount {
+            updateBestSymbol(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: true,
+                requireExternal: false
+            )
+        }
+    } else {
+        for i in symbols.indices {
+            updateBestSymbol(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: true,
+                requireExternal: isGlobalOnly
+            )
+        }
+    }
+
+    guard let bestIndex else { return nil }
+    return symbols.symbol(at: bestIndex, nlist: symbols.wrappedNlist(at: bestIndex))
+}
+
+extension MachORepresentable {
     public func closestSymbols( // swiftlint:disable:this cyclomatic_complexity
         at offset: Int,
         inSection sectionNumber: Int = 0,

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -378,7 +378,7 @@ extension MachORepresentable {
 }
 
 extension MachORepresentable where Self == MachOFile {
-    public func closestSymbol( // swiftlint:disable:this cyclomatic_complexity
+    public func closestSymbol(
         at offset: Int,
         inSection sectionNumber: Int = 0,
         isGlobalOnly: Bool = false
@@ -403,10 +403,34 @@ extension MachORepresentable where Self == MachOFile {
         return nil
     }
 
+    public func closestSymbols(
+        at offset: Int,
+        inSection sectionNumber: Int = 0,
+        isGlobalOnly: Bool = false
+    ) -> [Symbol] {
+        if is64Bit, let symbols64 {
+            return _closestSymbols(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols64
+            )
+        } else if let symbols32 {
+            return _closestSymbols(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols32
+            )
+        }
+        return []
+    }
 }
 
 extension MachORepresentable where Self == MachOImage {
-    public func closestSymbol( // swiftlint:disable:this cyclomatic_complexity
+    public func closestSymbol(
         at offset: Int,
         inSection sectionNumber: Int = 0,
         isGlobalOnly: Bool = false
@@ -431,6 +455,30 @@ extension MachORepresentable where Self == MachOImage {
         return nil
     }
 
+    public func closestSymbols(
+        at offset: Int,
+        inSection sectionNumber: Int = 0,
+        isGlobalOnly: Bool = false
+    ) -> [Symbol] {
+        if is64Bit, let symbols64 {
+            return _closestSymbols(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols64
+            )
+        } else if let symbols32 {
+            return _closestSymbols(
+                in: self,
+                at: offset,
+                inSection: sectionNumber,
+                isGlobalOnly: isGlobalOnly,
+                symbols: symbols32
+            )
+        }
+        return []
+    }
 }
 
 // ref: https://github.com/apple-oss-distributions/dyld/blob/93bd81f9d7fcf004fcebcb66ec78983882b41e71/common/MachOLoaded.cpp#L606
@@ -510,83 +558,88 @@ private func _closestSymbol<MachO, Table>( // swiftlint:disable:this cyclomatic_
     return symbols.symbol(at: bestIndex, nlist: symbols.wrappedNlist(at: bestIndex))
 }
 
-extension MachORepresentable {
-    public func closestSymbols( // swiftlint:disable:this cyclomatic_complexity
-        at offset: Int,
-        inSection sectionNumber: Int = 0,
-        isGlobalOnly: Bool = false
-    ) -> [Symbol] {
-        let symbols = self.symbols
-        var bestOffset: Int?
-        var bestSymbols: [Symbol] = []
+@inline(__always)
+private func _closestSymbols<MachO, Table>( // swiftlint:disable:this cyclomatic_complexity
+    in machO: MachO,
+    at offset: Int,
+    inSection sectionNumber: Int,
+    isGlobalOnly: Bool,
+    symbols: Table
+) -> [MachO.Symbol] where MachO: MachORepresentable, Table: _SymbolTableProtocol<MachO.Symbol> {
+    var bestOffset: Int?
+    var bestIndices: [Int] = []
 
-        func updateBestSymbols(_ symbol: Symbol) {
-            if let _bestOffset = bestOffset {
-                if _bestOffset > symbol.offset {
-                    return
-                } else if _bestOffset == symbol.offset {
-                    bestSymbols.append(symbol)
-                } else {
-                    bestOffset = symbol.offset
-                    bestSymbols = [symbol]
-                }
-            } else {
-                bestOffset = symbol.offset
-                bestSymbols = [symbol]
-            }
+    func updateBestSymbols(
+        at index: Int,
+        nlist: Table.WrappedNlist,
+        requireNonStab: Bool,
+        requireExternal: Bool
+    ) {
+        let flags = nlist.flags ?? .init(rawValue: 0)
+        let symbolOffset = symbols.offset(of: nlist)
+
+        guard flags.type == .sect,
+              !requireNonStab || flags.stab == nil,
+              symbolOffset <= offset,
+              !requireExternal || flags.contains(.ext),
+              sectionNumber == 0 || nlist.sectionNumber == sectionNumber else {
+            return
         }
-
-        if let dysym = loadCommands.dysymtab {
-            // find closest match in globals
-            let globalStart: Int = numericCast(dysym.iextdefsym)
-            let globalCount: Int = numericCast(dysym.nextdefsym)
-            for i in globalStart ..< globalStart + globalCount {
-                let symbol = symbols[AnyIndex(i)]
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-
-                guard nlist.flags?.type == .sect,
-                      symbol.offset <= offset,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                updateBestSymbols(symbol)
-            }
-            if isGlobalOnly { return bestSymbols }
-
-            // find closest match in locals
-            let localStart: Int = numericCast(dysym.ilocalsym)
-            let localCount: Int = numericCast(dysym.nlocalsym)
-            for i in localStart ..< localStart + localCount {
-                let symbol = symbols[AnyIndex(i)]
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-
-                guard nlist.flags?.type == .sect,
-                      nlist.flags?.stab == nil,
-                      symbol.offset <= offset,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                updateBestSymbols(symbol)
+        if let currentBestOffset = bestOffset {
+            if currentBestOffset > symbolOffset {
+                return
+            } else if currentBestOffset == symbolOffset {
+                bestIndices.append(index)
+            } else {
+                bestOffset = symbolOffset
+                bestIndices = [index]
             }
         } else {
-            // find closest match in locals
-            for symbol in symbols {
-                let nlist = symbol.nlist
-                let symbolSectionNumber = symbol.nlist.sectionNumber
-                guard nlist.flags?.type == .sect,
-                      nlist.flags?.stab == nil,
-                      symbol.offset <= offset,
-                      !isGlobalOnly || nlist.flags?.contains(.ext) ?? false,
-                      sectionNumber == 0 || symbolSectionNumber == sectionNumber else {
-                    continue
-                }
-                updateBestSymbols(symbol)
+            bestOffset = symbolOffset
+            bestIndices = [index]
+        }
+    }
+
+    if let dysym = machO.loadCommands.dysymtab {
+        let globalStart: Int = numericCast(dysym.iextdefsym)
+        let globalCount: Int = numericCast(dysym.nextdefsym)
+        for i in globalStart ..< globalStart + globalCount {
+            updateBestSymbols(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: false,
+                requireExternal: false
+            )
+        }
+        if isGlobalOnly {
+            return bestIndices.map {
+                symbols.symbol(at: $0, nlist: symbols.wrappedNlist(at: $0))
             }
         }
 
-        return bestSymbols
+        let localStart: Int = numericCast(dysym.ilocalsym)
+        let localCount: Int = numericCast(dysym.nlocalsym)
+        for i in localStart ..< localStart + localCount {
+            updateBestSymbols(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: true,
+                requireExternal: false
+            )
+        }
+    } else {
+        for i in symbols.indices {
+            updateBestSymbols(
+                at: i,
+                nlist: symbols.wrappedNlist(at: i),
+                requireNonStab: true,
+                requireExternal: isGlobalOnly
+            )
+        }
+    }
+
+    return bestIndices.map {
+        symbols.symbol(at: $0, nlist: symbols.wrappedNlist(at: $0))
     }
 }
 

--- a/Sources/MachOKit/Protocol/_SymbolTableProtocol.swift
+++ b/Sources/MachOKit/Protocol/_SymbolTableProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  _SymbolTableProtocol.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2026/06/19
+//  
+//
+
+protocol _SymbolTableProtocol<Symbol> {
+    associatedtype Symbol: SymbolProtocol
+    associatedtype WrappedNlist: NlistProtocol
+
+    var indices: Range<Int> { get }
+
+    func wrappedNlist(at position: Int) -> WrappedNlist
+    func offset(of nlist: WrappedNlist) -> Int
+    func symbol(at position: Int, nlist: WrappedNlist) -> Symbol
+}


### PR DESCRIPTION
## Summary

- Avoid materializing full symbol collections while resolving closest symbols.
- Add an internal symbol table abstraction for MachOFile and MachOImage symbol tables.
- Share the hot lookup path through private helpers while preserving file-backed and image-backed offset semantics.

## Validation

- `swift build`
- `swift test --filter MachOFilePrintTests.testClosestSymbol`
- `swift test --filter MachOPrintTests.testClosestSymbol`
- `swift test --filter MachOFilePrintTests.testSymbols`
- `swift test --filter MachOPrintTests.testSymbols`
- `make benchmark-baseline-compare BASELINE=closest-symbol-main BENCHMARK_ARGS='--filter "MachOFile\\.closestSymbol\\.repeated" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`

## Benchmark

`MachOFile.closestSymbol.repeated` improved from `1.48e+07 μs / 263G instructions` to about `1.08e+06 μs / 24G instructions` in local runs.

`closestSymbols` was aligned to the same implementation shape, but a dedicated benchmark has not been added yet.