### PR TITLE
Cache dyld cache mapping info sequences

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -41,6 +41,8 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
     private var _mainCache: DyldCache?
     // Retain the symbol cache
     internal var _symbolCache: DyldCache?
+    private var _mappingInfos: DataSequence<DyldCacheMappingInfo>?
+    private var _mappingAndSlideInfos: DataSequence<DyldCacheMappingAndSlideInfo>?
 
     public var headerSize: Int {
         header.actualSize
@@ -171,10 +173,13 @@ extension DyldCache {
     /// Sequence of mapping infos
     public var mappingInfos: DataSequence<DyldCacheMappingInfo>? {
         guard header.mappingCount > 0 else { return nil }
-        return fileHandle.readDataSequence(
+        if let _mappingInfos { return _mappingInfos }
+        let mappingInfos: DataSequence<DyldCacheMappingInfo> = fileHandle.readDataSequence(
             offset: numericCast(header.mappingOffset),
             numberOfElements: numericCast(header.mappingCount)
         )
+        _mappingInfos = mappingInfos
+        return mappingInfos
     }
 
     /// Sequence of mapping and slide infos
@@ -183,10 +188,13 @@ extension DyldCache {
               header.hasProperty(\.mappingWithSlideCount) else {
             return nil
         }
-        return fileHandle.readDataSequence(
+        if let _mappingAndSlideInfos { return _mappingAndSlideInfos }
+        let mappingAndSlideInfos: DataSequence<DyldCacheMappingAndSlideInfo> = fileHandle.readDataSequence(
             offset: numericCast(header.mappingWithSlideOffset),
             numberOfElements: numericCast(header.mappingWithSlideCount)
         )
+        _mappingAndSlideInfos = mappingAndSlideInfos
+        return mappingAndSlideInfos
     }
 
     /// Sequence of image infos.

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -35,6 +35,8 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
 
     // Retain the symbol cache
     private var _symbolCache: DyldCache?
+    private var _mappingInfos: [DyldCacheMappingInfo]?
+    private var _mappingAndSlideInfos: [DyldCacheMappingAndSlideInfo]?
 
     public var headerSize: Int {
         header.actualSize
@@ -120,7 +122,8 @@ extension FullDyldCache {
 extension FullDyldCache {
     /// Sequence of mapping infos
     public var mappingInfos: [DyldCacheMappingInfo]? {
-        zip(fileHandle._files, allCaches).compactMap { file, cache in
+        if let _mappingInfos { return _mappingInfos }
+        let mappingInfos = zip(fileHandle._files, allCaches).compactMap { file, cache in
             cache.mappingInfos?
                 .map {
                     $0.withFileOffset(
@@ -128,11 +131,14 @@ extension FullDyldCache {
                     )
                 }
         }.flatMap { $0 }
+        _mappingInfos = mappingInfos
+        return mappingInfos
     }
 
     /// Sequence of mapping and slide infos
     public var mappingAndSlideInfos: [DyldCacheMappingAndSlideInfo]? {
-        zip(fileHandle._files, allCaches).compactMap { file, cache in
+        if let _mappingAndSlideInfos { return _mappingAndSlideInfos }
+        let mappingAndSlideInfos = zip(fileHandle._files, allCaches).compactMap { file, cache in
             cache.mappingAndSlideInfos?
                 .map {
                     $0.withFileOffset(
@@ -143,6 +149,8 @@ extension FullDyldCache {
                     )
                 }
         }.flatMap { $0 }
+        _mappingAndSlideInfos = mappingAndSlideInfos
+        return mappingAndSlideInfos
     }
 
     /// Sequence of image infos.


### PR DESCRIPTION
## Summary
- Cache `DyldCache.mappingInfos` and `DyldCache.mappingAndSlideInfos` after their first construction.
- Cache flattened `FullDyldCache` mapping info arrays so repeated lookups do not rebuild subcache-wide mapping lists.

## Performance
`make benchmark-baseline-compare BASELINE=main BENCHMARK_ARGS='--filter "(DyldCache|FullDyldCache)\\.(mappingInfo\\.lookup|fileOffset\\.translate|address\\.translate)" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`

p50 improvements:
- `DyldCache.address.translate`: 50% wall clock, 52% instructions
- `DyldCache.fileOffset.translate`: 53% wall clock, 56% instructions
- `DyldCache.mappingInfo.lookup`: 51% wall clock, 53% instructions
- `FullDyldCache.fileOffset.translate`: 92% wall clock, 92% instructions
- `FullDyldCache.mappingInfo.lookup`: 92% wall clock, 92% instructions

## Validation
- `swift build`
- `swift test --filter DyldCache`