### PR TITLE
Avoid eager main cache creation for subcaches

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -128,7 +128,8 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
         url: URL,
         cpu: CPU,
         header: DyldCacheHeader? = nil,
-        mainCache: DyldCache? = nil
+        mainCache: DyldCache? = nil,
+        mainCacheHeader: DyldCacheHeader? = nil
     ) {
         self.fileHandle = fileHandle
         self.url = url
@@ -139,14 +140,18 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
         )
         self.cpu = cpu
         self._mainCache = mainCache
-        self._mainCacheHeader = mainCache?.header
+        self._mainCacheHeader = mainCache?.header ?? mainCacheHeader
     }
 }
 
 extension DyldCache {
     public var mainCache: DyldCache? {
         if let _mainCache { return _mainCache }
-        if let _fullCache { return _fullCache.mainCache }
+        if let _fullCache {
+            let mainCache = _fullCache.mainCache
+            _mainCache = mainCache
+            return mainCache
+        }
         if url.lastPathComponent.contains(".") {
             let url = url
                 .deletingPathExtension()

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -148,6 +148,7 @@ extension DyldCache {
     public var mainCache: DyldCache? {
         if let _mainCache { return _mainCache }
         if let _fullCache {
+            if _fullCache.url == url { return self }
             let mainCache = _fullCache.mainCache
             _mainCache = mainCache
             return mainCache

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -108,9 +108,8 @@ extension FullDyldCache {
     }
 
     public var subCaches: [DyldCache] {
-        let mainCache = self.mainCache
         return (1..<fileHandle._files.count).map {
-            cache(atIndex: $0, mainCache: mainCache)
+            cache(atIndex: $0)
         }
     }
 
@@ -346,7 +345,8 @@ extension FullDyldCache {
             url: urls[index],
             cpu: cpu,
             header: subCacheHeaders[index - 1],
-            mainCache: mainCache ?? self.mainCache
+            mainCache: mainCache,
+            mainCacheHeader: header
         )
         cache._fullCache = self
         return cache


### PR DESCRIPTION
## Summary

- Avoid creating a main `DyldCache` wrapper when building full dyld subcache wrappers unless the caller already provides one.
- Pass the preloaded full-cache header into subcache wrappers so `mainCacheHeader` remains available without forcing main cache construction.
- Memoize `DyldCache.mainCache` when it is first resolved through a `FullDyldCache`.

## Performance

This keeps the `FullDyldCache.machOFiles()` path on the existing efficient shape that creates one shared main cache wrapper for enumeration, while improving lookup-style paths that only need a single subcache wrapper.

Compared with the refreshed `main-current` benchmark baseline:

- `FullDyldCache.cache.forOffset`: p50 wall clock improved by about 33%; p50 instructions improved by about 33%.
- `FullDyldCache.cache.forURL`: p50 wall clock improved by about 24%; p50 instructions improved by about 24%.
- `FullDyldCache.resolveRebase` / `resolveOptionalRebase`: effectively unchanged; small wall-clock differences are within benchmark noise.

## Validation

- `swift build`
- `make benchmark-baseline-compare BASELINE=main-current BENCHMARK_ARGS='--filter "FullDyldCache\.(machOFiles\.enumerate|fileOffset\.translate|mappingInfo\.lookup|cache\.forOffset|cache\.forURL|resolveRebase|resolveOptionalRebase)" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`