### PR TITLE
Cache dyld mapping info arrays

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -41,8 +41,8 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
     private var _mainCache: DyldCache?
     // Retain the symbol cache
     internal var _symbolCache: DyldCache?
-    private var _mappingInfos: DataSequence<DyldCacheMappingInfo>?
-    private var _mappingAndSlideInfos: DataSequence<DyldCacheMappingAndSlideInfo>?
+    private var _mappingInfos: [DyldCacheMappingInfo]?
+    private var _mappingAndSlideInfos: [DyldCacheMappingAndSlideInfo]?
 
     public var headerSize: Int {
         header.actualSize
@@ -177,19 +177,20 @@ extension DyldCache {
 
 extension DyldCache {
     /// Sequence of mapping infos
-    public var mappingInfos: DataSequence<DyldCacheMappingInfo>? {
+    public var mappingInfos: [DyldCacheMappingInfo]? {
         guard header.mappingCount > 0 else { return nil }
         if let _mappingInfos { return _mappingInfos }
         let mappingInfos: DataSequence<DyldCacheMappingInfo> = fileHandle.readDataSequence(
             offset: numericCast(header.mappingOffset),
             numberOfElements: numericCast(header.mappingCount)
         )
-        _mappingInfos = mappingInfos
-        return mappingInfos
+        let _mappingInfos = Array(mappingInfos)
+        self._mappingInfos = _mappingInfos
+        return _mappingInfos
     }
 
     /// Sequence of mapping and slide infos
-    public var mappingAndSlideInfos: DataSequence<DyldCacheMappingAndSlideInfo>? {
+    public var mappingAndSlideInfos: [DyldCacheMappingAndSlideInfo]? {
         guard header.mappingWithSlideCount > 0,
               header.hasProperty(\.mappingWithSlideCount) else {
             return nil
@@ -199,8 +200,9 @@ extension DyldCache {
             offset: numericCast(header.mappingWithSlideOffset),
             numberOfElements: numericCast(header.mappingWithSlideCount)
         )
-        _mappingAndSlideInfos = mappingAndSlideInfos
-        return mappingAndSlideInfos
+        let _mappingAndSlideInfos = Array(mappingAndSlideInfos)
+        self._mappingAndSlideInfos = _mappingAndSlideInfos
+        return _mappingAndSlideInfos
     }
 
     /// Sequence of image infos.

--- a/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
+++ b/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
@@ -3,7 +3,7 @@
 //  MachOKit
 //
 //  Created by p-x9 on 2025/07/19
-//  
+//
 //
 
 import Foundation
@@ -16,13 +16,71 @@ internal import FileIOBinary
 #endif
 
 internal protocol _DyldCacheFileRepresentable: DyldCacheRepresentable
-where DylibsTrie == DataTrieTree<DylibsTrieNodeContent>,
+where MappingInfos == [DyldCacheMappingInfo],
+      MappingAndSlideInfos == [DyldCacheMappingAndSlideInfo],
+      DylibsTrie == DataTrieTree<DylibsTrieNodeContent>,
       ProgramsTrie == DataTrieTree<ProgramsTrieNodeContent>
 {
     associatedtype File: MemoryMappedFileIOProtocol
     var fileHandle: File { get }
 
     func machOFiles() -> AnySequence<MachOFile>
+}
+
+extension _DyldCacheFileRepresentable {
+    @inline(__always)
+    public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
+        guard let mappings = mappingInfos else { return nil }
+        for mapping in mappings {
+            if mapping.address <= address,
+               address < mapping.address + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    @inline(__always)
+    public func mappingInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingInfo? {
+        guard let mappings = mappingInfos else { return nil }
+        for mapping in mappings {
+            if mapping.fileOffset <= offset,
+               offset < mapping.fileOffset + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    @inline(__always)
+    public func mappingAndSlideInfo(
+        for address: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = mappingAndSlideInfos else { return nil }
+        for mapping in mappings {
+            if mapping.address <= address,
+               address < mapping.address + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    @inline(__always)
+    public func mappingAndSlideInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = mappingAndSlideInfos else { return nil }
+        for mapping in mappings {
+            if mapping.fileOffset <= offset,
+               offset < mapping.fileOffset + mapping.size {
+                return mapping
+            }
+        }
+        return nil
+    }
 }
 
 extension _DyldCacheFileRepresentable {


### PR DESCRIPTION
## Summary

- Cache `DyldCache` mapping info and mapping-and-slide info as arrays instead of retaining lazy `DataSequence` values.
- Constrain file-backed dyld cache representations to array-backed mapping collections.
- Move optimized mapping lookup defaults onto `_DyldCacheFileRepresentable` with `@inline(__always)` so `DyldCache` and `FullDyldCache` share the implementation without concrete duplicate overrides.

## Motivation

Repeated dyld cache address, file offset, and rebase resolution paths were paying unnecessary sequence traversal overhead. Materializing the mapping metadata once as arrays lets lookup-heavy paths iterate over concrete contiguous storage, while the constrained default keeps the fast implementation shared by file-backed cache types.

During tuning, concrete lookup overrides on `DyldCache` recovered most of the performance, but duplicated the same lookup logic. Moving the implementation to `_DyldCacheFileRepresentable` without inlining kept the implementation shared but regressed direct lookup throughput. Adding `@inline(__always)` to the constrained default recovered concrete-override-level performance while keeping the implementation centralized.

## Lookup Implementation Comparison

`DyldCache.mappingInfo.lookup` against the same `main-array-focused` baseline:

| Implementation | p50 wall clock | p50 instructions |
| --- | ---: | ---: |
| Baseline | `41189 μs` | `794M` |
| Array + concrete `DyldCache` overrides | `4094 μs` | `60M` |
| Array + shared `_DyldCacheFileRepresentable` default, no inline | `5632 μs` | `116M` |
| Array + shared `_DyldCacheFileRepresentable` default + `@inline(__always)` | `3682 μs` | `62M` |

## Validation

- `swift build`
- `make benchmark-baseline-compare BASELINE=main-array-focused BENCHMARK_ARGS='--filter "DyldCache\\.mappingInfo\\.lookup" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`
  - p50 wall clock: `41189 -> 3682 μs`
  - p50 instructions: `794M -> 62M`
- `make benchmark-baseline-compare BASELINE=main-array-focused BENCHMARK_ARGS='--filter "DyldCache\\.resolveRebase" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`
  - p50 wall clock: `5825 -> 1780 μs`
  - p50 instructions: `119M -> 35M`
- `make benchmark-baseline-compare BASELINE=main-array-focused BENCHMARK_ARGS='--filter "FullDyldCache\\.resolveRebase" --metric wallClock --metric instructions --no-progress --scale --time-units microseconds'`
  - p50 wall clock: `32211 -> 1818 μs`
  - p50 instructions: `580M -> 35M`