### PR TITLE
Avoid segment array allocation in address lookups

### DIFF
--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -885,13 +885,26 @@ extension MachOFile {
         if let cache {
             return cache.fileOffset(of: vmaddr)
         }
-        for segment in self.segments {
-            if segment.virtualMemoryAddress <= vmaddr,
-               vmaddr < segment.virtualMemoryAddress + segment.virtualMemorySize {
-                return vmaddr + numericCast(segment.fileOffset) - numericCast(segment.virtualMemoryAddress)
+        if is64Bit {
+            return _fileOffset(of: vmaddr, in: segments64)
+        } else {
+            return _fileOffset(of: vmaddr, in: segments32)
+        }
+    }
+
+    @inline(__always)
+    private func _fileOffset<Segments: Sequence>(
+        of vmaddr: UInt64,
+        in segments: Segments
+    ) -> UInt64? where Segments.Element: SegmentCommandProtocol {
+        for segment in segments {
+            let segmentVMAddr = UInt64(segment.virtualMemoryAddress)
+            if segmentVMAddr <= vmaddr,
+               vmaddr < segmentVMAddr + UInt64(segment.virtualMemorySize) {
+                return vmaddr + UInt64(segment.fileOffset) - segmentVMAddr
             }
-            if segment.segmentName == SEG_TEXT,
-               vmaddr < segment.virtualMemoryAddress {
+            if vmaddr < segmentVMAddr,
+               segment.segmentName == SEG_TEXT {
                 return vmaddr
             }
         }

--- a/Sources/MachOKit/Protocol/MachORepresentable.swift
+++ b/Sources/MachOKit/Protocol/MachORepresentable.swift
@@ -963,12 +963,25 @@ extension MachORepresentable where IndirectSymbols.Index == Int {
 
 extension MachORepresentable {
     public func contains(unslidAddress address: UInt64) -> Bool {
-        segments.contains(
-            where: {
-                $0.contains(unslidAddress: address)
-            }
-        )
+        if is64Bit {
+            _contains(unslidAddress: address, in: segments64)
+        } else {
+            _contains(unslidAddress: address, in: segments32)
+        }
     }
+}
+
+@inline(__always)
+private func _contains<Segments: Sequence>(
+    unslidAddress address: UInt64,
+    in segments: Segments
+) -> Bool where Segments.Element: SegmentCommandProtocol {
+    for segment in segments {
+        if segment.contains(unslidAddress: address) {
+            return true
+        }
+    }
+    return false
 }
 
 extension MachORepresentable {


### PR DESCRIPTION
## Summary

- Iterate concrete 32-bit and 64-bit segment sequences directly in `MachOFile.fileOffset(of:)`.
- Avoid the public `segments` array path in `MachORepresentable.contains(unslidAddress:)`.
- Keep the `__TEXT` fallback in `fileOffset(of:)` while avoiding segment name construction unless the address is below the segment.

## Benchmark

Compared against the current baseline:

- `MachOFile.contains.unslidAddress`: p50 wall `2912us -> 580us`, instructions `61M -> 12M`.
- `MachOFile.fileOffset.translate`: p50 wall `13ms -> 10ms`, instructions `218M -> 174M`.

## Validation

- `swift build`
- `make benchmark-baseline-compare`