### PR TITLE
Expose handle-scoped identity tokens for SPI clients

### DIFF
--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -20,6 +20,27 @@ internal import FileIO
 /// This identity represents the object identity of the handle shared by
 /// MachOKit wrappers. It is not a file-system identity: separately opened
 /// handles for the same path may have different identities.
+///
+/// Example:
+/// ```swift
+/// @_spi(Support) import MachOKit
+///
+/// final class ParsedFileCache {}
+///
+/// final class ExternalCacheStore {
+///     private let caches = WeakMapTable<any FileHandleIdentity, ParsedFileCache>()
+///
+///     func cache(for machO: MachOFile) -> ParsedFileCache {
+///         let owner = machO.fileHandleIdentity
+///         if let cache = caches[owner] {
+///             return cache
+///         }
+///         let cache = ParsedFileCache()
+///         caches[owner] = cache
+///         return cache
+///     }
+/// }
+/// ```
 @_spi(Support)
 @_marker
 public protocol FileHandleIdentity: AnyObject {}

--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -7,19 +7,15 @@
 //
 
 import Foundation
-#if compiler(>=6.0) || (compiler(>=5.10) && hasFeature(AccessLevelOnImport))
-internal import FileIO
-#else
-@_implementationOnly import FileIO
-#endif
 
 // MARK: - file handle identity
 
 /// A marker protocol for objects that identify a MachOKit backing file handle.
 ///
-/// This identity represents the object identity of the handle shared by
-/// MachOKit wrappers. It is not a file-system identity: separately opened
-/// handles for the same path may have different identities.
+/// This identity represents a MachOKit-owned token associated with the backing
+/// handle shared by MachOKit wrappers. It is not the file handle itself, and it
+/// is not a file-system identity: separately opened handles for the same path
+/// may have different identities.
 ///
 /// Example:
 /// ```swift
@@ -45,10 +41,39 @@ internal import FileIO
 @_marker
 public protocol FileHandleIdentity: AnyObject {}
 
-@_spi(Support)
-extension MemoryMappedFile: FileHandleIdentity {}
-@_spi(Support)
-extension ConcatenatedMemoryMappedFile: FileHandleIdentity {}
+final class FileHandleIdentityBox: FileHandleIdentity {}
+
+private final class FileHandleIdentityStorage: @unchecked Sendable {
+    private let lock = NSLock()
+    #if canImport(ObjectiveC)
+    private let entries = NSMapTable<AnyObject, FileHandleIdentityBox>.weakToStrongObjects()
+    #else
+    private var entries = WeakKeyStrongValueMap<AnyObject, FileHandleIdentityBox>()
+    #endif
+
+    @inline(__always)
+    func identity(for fileHandle: AnyObject) -> FileHandleIdentityBox {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let identity = entries.object(forKey: fileHandle) {
+            return identity
+        }
+
+        let identity = FileHandleIdentityBox()
+        entries.setObject(identity, forKey: fileHandle)
+        return identity
+    }
+}
+
+enum FileHandleIdentityStore {
+    private static let storage = FileHandleIdentityStorage()
+
+    @inline(__always)
+    static func identity(for fileHandle: AnyObject) -> FileHandleIdentityBox {
+        storage.identity(for: fileHandle)
+    }
+}
 
 extension MachOFile {
     /// The identity of the backing file handle used by this Mach-O file.
@@ -58,7 +83,10 @@ extension MachOFile {
     /// weak caches that should follow the lifetime of the shared handle, not as
     /// a path or inode equivalence check.
     @_spi(Support)
-    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+    @inline(__always)
+    public var fileHandleIdentity: any FileHandleIdentity {
+        FileHandleIdentityStore.identity(for: fileHandle)
+    }
 }
 
 extension DyldCache {
@@ -68,7 +96,10 @@ extension DyldCache {
     /// identity, allowing external SPI clients to share handle-scoped caches
     /// without exposing the file handle itself.
     @_spi(Support)
-    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+    @inline(__always)
+    public var fileHandleIdentity: any FileHandleIdentity {
+        FileHandleIdentityStore.identity(for: fileHandle)
+    }
 }
 
 extension FullDyldCache {
@@ -78,7 +109,10 @@ extension FullDyldCache {
     /// `DyldCache` values produced from it may expose the identity of their
     /// underlying cache-file handle instead.
     @_spi(Support)
-    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+    @inline(__always)
+    public var fileHandleIdentity: any FileHandleIdentity {
+        FileHandleIdentityStore.identity(for: fileHandle)
+    }
 }
 
 extension AotCache {
@@ -88,5 +122,8 @@ extension AotCache {
     /// follow the lifetime of the AOT cache's mapped file handle, not as a path
     /// or inode equivalence check.
     @_spi(Support)
-    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+    @inline(__always)
+    public var fileHandleIdentity: any FileHandleIdentity {
+        FileHandleIdentityStore.identity(for: fileHandle)
+    }
 }

--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -7,7 +7,11 @@
 //
 
 import Foundation
+#if compiler(>=6.0) || (compiler(>=5.10) && hasFeature(AccessLevelOnImport))
 internal import FileIO
+#else
+@_implementationOnly import FileIO
+#endif
 
 // MARK: - file handle identity
 

--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -57,7 +57,11 @@ extension FullDyldCache {
 }
 
 extension AotCache {
-    /// The identity of the concatenated backing handle used by this aot cache.
+    /// The identity of the backing file handle used by this AOT cache file.
+    ///
+    /// Use this value as an owner key for external weak caches that should
+    /// follow the lifetime of the AOT cache's mapped file handle, not as a path
+    /// or inode equivalence check.
     @_spi(Support)
     public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
 }

--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -1,0 +1,63 @@
+//
+//  MachOKit+FileIdentity.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2026/06/30
+//
+//
+
+import Foundation
+internal import FileIO
+
+// MARK: - file handle identity
+
+/// A marker protocol for objects that identify a MachOKit backing file handle.
+///
+/// This identity represents the object identity of the handle shared by
+/// MachOKit wrappers. It is not a file-system identity: separately opened
+/// handles for the same path may have different identities.
+@_spi(Support)
+@_marker
+public protocol FileHandleIdentity: AnyObject {}
+
+@_spi(Support)
+extension MemoryMappedFile: FileHandleIdentity {}
+@_spi(Support)
+extension ConcatenatedMemoryMappedFile: FileHandleIdentity {}
+
+extension MachOFile {
+    /// The identity of the backing file handle used by this Mach-O file.
+    ///
+    /// `MachOFile` instances created from a `DyldCache` share the cache's
+    /// backing handle identity. Use this value as an owner key for external
+    /// weak caches that should follow the lifetime of the shared handle, not as
+    /// a path or inode equivalence check.
+    @_spi(Support)
+    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+}
+
+extension DyldCache {
+    /// The identity of the backing file handle used by this dyld cache file.
+    ///
+    /// Mach-O files produced from this cache inherit the same backing handle
+    /// identity, allowing external SPI clients to share handle-scoped caches
+    /// without exposing the file handle itself.
+    @_spi(Support)
+    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+}
+
+extension FullDyldCache {
+    /// The identity of the concatenated backing handle used by this full dyld cache.
+    ///
+    /// This identifies the `FullDyldCache`'s composite handle. Individual
+    /// `DyldCache` values produced from it may expose the identity of their
+    /// underlying cache-file handle instead.
+    @_spi(Support)
+    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+}
+
+extension AotCache {
+    /// The identity of the concatenated backing handle used by this aot cache.
+    @_spi(Support)
+    public var fileHandleIdentity: any FileHandleIdentity { fileHandle }
+}

--- a/Sources/MachOKit/Util/WeakKeyStrongValueMap.swift
+++ b/Sources/MachOKit/Util/WeakKeyStrongValueMap.swift
@@ -1,0 +1,47 @@
+//
+//  WeakKeyStrongValueMap.swift
+//  MachOKit
+//
+//  Created by p-x9 on 2026/02/08
+//
+//
+
+import Foundation
+
+#if !canImport(ObjectiveC)
+final class WeakBox<Value: AnyObject> {
+    weak var value: Value?
+    let id: ObjectIdentifier
+
+    init(_ value: Value) {
+        self.value = value
+        self.id = ObjectIdentifier(value)
+    }
+}
+
+struct WeakKeyStrongValueMap<Key: AnyObject, Value> {
+    private var storage: [ObjectIdentifier: (key: WeakBox<Key>, value: Value)] = [:]
+
+    mutating func object(forKey key: Key) -> Value? {
+        let id = ObjectIdentifier(key)
+        if let entry = storage[id] {
+            if entry.key.value != nil {
+                return entry.value
+            }
+            storage[id] = nil
+        }
+        cleanupIfNeeded()
+        return nil
+    }
+
+    mutating func setObject(_ value: Value, forKey key: Key) {
+        cleanupIfNeeded()
+        let box = WeakBox(key)
+        storage[box.id] = (box, value)
+    }
+
+    private mutating func cleanupIfNeeded() {
+        storage = storage.filter { $0.value.key.value != nil }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Add a Support SPI `FileHandleIdentity` marker protocol and expose `fileHandleIdentity` from `MachOFile`, `DyldCache`, `FullDyldCache`, and `AotCache`.
- Return MachOKit-owned identity tokens instead of exposing FileIO handle objects as identities.
- Keep each token stable while its backing file handle is alive by storing it in a weak-key/strong-value map.
- Use `NSMapTable.weakToStrongObjects()` when Objective-C is available, with a Swift fallback for supported environments where it is not.

## Motivation

External SPI clients may need owner-keyed caches shared by MachOKit wrappers that inherit the same backing file handle. The cache owner must follow the ARC lifetime of that handle, while the underlying FileIO object remains an implementation detail.

Returning the FileIO handle itself as `any FileHandleIdentity` would allow clients that also import FileIO to downcast the value and recover the internal handle API. This implementation instead returns an opaque MachOKit-owned token associated with the handle. Separately opened handles for the same path still receive different identities.

`FullDyldCache.fileHandleIdentity` identifies its composite handle. Individual `DyldCache` values may identify their underlying cache-file handles instead.

## Example

```swift
@_spi(Support) import MachOKit

final class ParsedFileCache {}

final class ExternalCacheStore {
    private let caches = WeakMapTable<any FileHandleIdentity, ParsedFileCache>()

    func cache(for machO: MachOFile) -> ParsedFileCache {
        let owner = machO.fileHandleIdentity
        if let cache = caches[owner] {
            return cache
        }

        let cache = ParsedFileCache()
        caches[owner] = cache
        return cache
    }
}
```

## Validation

- `swift build`
