### PR TITLE
Expose cached dyld cache SPI getters

### DIFF
--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -190,7 +190,10 @@ extension DyldCache {
     @_spi(Support)
     public var _cachedMainCache: DyldCache? {
         if let _mainCache { return _mainCache }
-        if _fullCache?.url == url { return self }
+        if let _fullCache {
+            if _fullCache.url == url { return self }
+            return _fullCache.mainCache
+        }
         if !url.lastPathComponent.contains(".") { return self }
         return nil
     }

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -190,10 +190,7 @@ extension DyldCache {
     @_spi(Support)
     public var _cachedMainCache: DyldCache? {
         if let _mainCache { return _mainCache }
-        if let _fullCache {
-            if _fullCache.url == url { return self }
-            return _fullCache.mainCache
-        }
+        if _fullCache?.url == url { return self }
         if !url.lastPathComponent.contains(".") { return self }
         return nil
     }

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -183,17 +183,6 @@ extension DyldCache {
     public var _cachedFullCache: FullDyldCache? {
         _fullCache
     }
-
-    /// The cached main `DyldCache`, if one is already available without loading it.
-    ///
-    /// Unlike ``mainCache``, this property does not lazily create or load the main cache.
-    @_spi(Support)
-    public var _cachedMainCache: DyldCache? {
-        if let _mainCache { return _mainCache }
-        if _fullCache?.url == url { return self }
-        if !url.lastPathComponent.contains(".") { return self }
-        return nil
-    }
 }
 
 extension DyldCache {

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -176,6 +176,27 @@ extension DyldCache {
 }
 
 extension DyldCache {
+    /// The cached `FullDyldCache`, if one is already associated with this cache.
+    ///
+    /// Unlike ``fullCache``, this property does not lazily create or load a full cache.
+    @_spi(Support)
+    public var _cachedFullCache: FullDyldCache? {
+        _fullCache
+    }
+
+    /// The cached main `DyldCache`, if one is already available without loading it.
+    ///
+    /// Unlike ``mainCache``, this property does not lazily create or load the main cache.
+    @_spi(Support)
+    public var _cachedMainCache: DyldCache? {
+        if let _mainCache { return _mainCache }
+        if _fullCache?.url == url { return self }
+        if !url.lastPathComponent.contains(".") { return self }
+        return nil
+    }
+}
+
+extension DyldCache {
     /// Sequence of mapping infos
     public var mappingInfos: [DyldCacheMappingInfo]? {
         guard header.mappingCount > 0 else { return nil }

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -664,7 +664,12 @@ extension MachOFile {
     /// Unlike ``cache``, this property does not lazily create or load a cache.
     @_spi(Support)
     public var _cachedCache: DyldCache? {
-        _cache
+        if let _cache { return _cache }
+        // Since fullCache retains the fileHandle, it can be retrieved at virtually no cost.
+        if let fullCache {
+            return fullCache.cache(for: url)
+        }
+        return nil
     }
 
     /// The cached `FullDyldCache`, if one is already associated with this file.

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -659,6 +659,24 @@ extension MachOFile {
 }
 
 extension MachOFile {
+    /// The cached `DyldCache`, if one is already associated with this file.
+    ///
+    /// Unlike ``cache``, this property does not lazily create or load a cache.
+    @_spi(Support)
+    public var _cachedCache: DyldCache? {
+        _cache
+    }
+
+    /// The cached `FullDyldCache`, if one is already associated with this file.
+    ///
+    /// Unlike ``fullCache``, this property does not lazily create or load a full cache.
+    @_spi(Support)
+    public var _cachedFullCache: FullDyldCache? {
+        _fullCache
+    }
+}
+
+extension MachOFile {
     public var cfStrings64: DataSequence<CFString64>? {
         guard let section = sections64.first(where: {
             $0.sectionName == "__cfstring"

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -618,7 +618,7 @@ extension MachOFile {
     ///
     /// This property attempts to lazily load the dyld cache based on the file URL.
     /// - If `_cache` has already been set, that value is returned.
-    /// - If `fullCache` is available, the corresponding subcache for this file URL is returned.
+    /// - If `_fullCache` has already been set, the corresponding subcache for this file URL is returned.
     /// - Otherwise, this attempts to initialize a new `DyldCache` using the file URL.
     ///
     /// This is mainly used when the Mach-O file originates from a dyld shared cache and requires
@@ -658,13 +658,14 @@ extension MachOFile {
 }
 
 extension MachOFile {
-    /// The cached `DyldCache`, if one is already associated with this file.
+    /// The cached or cheaply recoverable `DyldCache`, if one is already associated with this file.
     ///
-    /// Unlike ``cache``, this property does not lazily create or load a cache.
+    /// Unlike ``cache``, this property does not load a `FullDyldCache` or open a cache file.
+    /// If `_fullCache` is already associated with this file, this may assemble a `DyldCache`
+    /// wrapper from the existing file handles and preloaded headers.
     @_spi(Support)
     public var _cachedCache: DyldCache? {
         if let _cache { return _cache }
-        // Since fullCache retains the fileHandle, it can be retrieved at virtually no cost.
         if let _fullCache {
             return _fullCache.cache(for: url)
         }

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -672,7 +672,7 @@ extension MachOFile {
     /// Unlike ``fullCache``, this property does not lazily create or load a full cache.
     @_spi(Support)
     public var _cachedFullCache: FullDyldCache? {
-        _fullCache
+        _fullCache ?? _cache?._fullCache
     }
 }
 

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -666,8 +666,8 @@ extension MachOFile {
     public var _cachedCache: DyldCache? {
         if let _cache { return _cache }
         // Since fullCache retains the fileHandle, it can be retrieved at virtually no cost.
-        if let fullCache {
-            return fullCache.cache(for: url)
+        if let _fullCache {
+            return _fullCache.cache(for: url)
         }
         return nil
     }

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -625,11 +625,10 @@ extension MachOFile {
     /// access to symbols, sections, or other data spread across subcaches.
     public var cache: DyldCache? {
         if let _cache { return _cache }
-        if let fullCache {
-            return fullCache.cache(for: url)
+        if let _fullCache {
+            return _fullCache.cache(for: url)
         }
         _cache = try? .init(url: url)
-        _cache?._fullCache = _fullCache
         return _cache
     }
 


### PR DESCRIPTION
## Summary
- Add Support SPI getters for cached dyld cache relationships without loading a full cache or opening a cache file.
- Expose `_cachedCache` and `_cachedFullCache` on `MachOFile`.
- Expose `_cachedFullCache` on `DyldCache`.

## Motivation
Some support-layer callers need to reuse already-associated dyld cache objects, or cheaply recover a `DyldCache` wrapper from an already-associated `FullDyldCache`, while avoiding the cost and side effects of the public `cache` and `fullCache` lazy properties. These underscored SPI getters make that contract explicit without exposing the stored properties themselves.

## Notes
- `_cachedMainCache` is intentionally not exposed.
- `DyldCache.mainCache` is expected to be available through the regular API when callers need it.
- Returning a main cache through `FullDyldCache.mainCache` would assemble a `DyldCache`, so it does not fit the current SPI surface.
- `MachOFile._cachedCache` may assemble a `DyldCache` wrapper when `_fullCache` is already present, but it does not load a `FullDyldCache` or open a cache file.

## Validation
- `swift build`