### PR TITLE
Optimize FullDyldCache mapping lookup

### DIFF
--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -377,14 +377,14 @@ extension FullDyldCache {
 }
 
 extension FullDyldCache {
-    private static let mappingBinarySearchThreshold = 32
+    private static let mappingBinarySearchThreshold = 64
 
     @inline(__always)
     private func findMapping<C: RandomAccessCollection>(
         in mappings: C,
         containing value: UInt64,
-        sortedBy lowerBound: KeyPath<C.Element, UInt64>,
-        size: KeyPath<C.Element, UInt64>
+        sortedBy lowerBound: (C.Element) -> UInt64,
+        size: (C.Element) -> UInt64
     ) -> C.Element? {
         if mappings.count < Self.mappingBinarySearchThreshold {
             return linearFindMapping(
@@ -406,12 +406,12 @@ extension FullDyldCache {
     private func linearFindMapping<C: Collection>(
         in mappings: C,
         containing value: UInt64,
-        lowerBound: KeyPath<C.Element, UInt64>,
-        size: KeyPath<C.Element, UInt64>
+        lowerBound: (C.Element) -> UInt64,
+        size: (C.Element) -> UInt64
     ) -> C.Element? {
         for mapping in mappings {
-            let start = mapping[keyPath: lowerBound]
-            if value >= start && value - start < mapping[keyPath: size] {
+            let start = lowerBound(mapping)
+            if value >= start && value - start < size(mapping) {
                 return mapping
             }
         }
@@ -422,8 +422,8 @@ extension FullDyldCache {
     private func binaryFindMapping<C: RandomAccessCollection>(
         in mappings: C,
         containing value: UInt64,
-        sortedBy lowerBound: KeyPath<C.Element, UInt64>,
-        size: KeyPath<C.Element, UInt64>
+        sortedBy lowerBound: (C.Element) -> UInt64,
+        size: (C.Element) -> UInt64
     ) -> C.Element? {
         var lower = mappings.startIndex
         var upper = mappings.endIndex
@@ -432,7 +432,7 @@ extension FullDyldCache {
             let distance = mappings.distance(from: lower, to: upper)
             let middle = mappings.index(lower, offsetBy: distance / 2)
 
-            if mappings[middle][keyPath: lowerBound] <= value {
+            if lowerBound(mappings[middle]) <= value {
                 lower = mappings.index(after: middle)
             } else {
                 upper = middle
@@ -442,7 +442,7 @@ extension FullDyldCache {
         guard lower != mappings.startIndex else { return nil }
 
         let candidate = mappings[mappings.index(before: lower)]
-        let start = candidate[keyPath: lowerBound]
-        return value >= start && value - start < candidate[keyPath: size] ? candidate : nil
+        let start = lowerBound(candidate)
+        return value >= start && value - start < size(candidate) ? candidate : nil
     }
 }

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -327,3 +327,122 @@ extension FullDyldCache {
         return cache
     }
 }
+
+extension FullDyldCache {
+    public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
+        guard let mappings = self.mappingInfos else { return nil }
+        return findMapping(
+            in: mappings,
+            containing: address,
+            sortedBy: \DyldCacheMappingInfo.address,
+            size: \DyldCacheMappingInfo.size
+        )
+    }
+
+    public func mappingInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingInfo? {
+        guard let mappings = self.mappingInfos else { return nil }
+        return findMapping(
+            in: mappings,
+            containing: offset,
+            sortedBy: \DyldCacheMappingInfo.fileOffset,
+            size: \DyldCacheMappingInfo.size
+        )
+    }
+
+    public func mappingAndSlideInfo(
+        for address: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = self.mappingAndSlideInfos else { return nil }
+        return findMapping(
+            in: mappings,
+            containing: address,
+            sortedBy: \DyldCacheMappingAndSlideInfo.address,
+            size: \DyldCacheMappingAndSlideInfo.size
+        )
+    }
+
+    public func mappingAndSlideInfo(
+        forFileOffset offset: UInt64
+    ) -> DyldCacheMappingAndSlideInfo? {
+        guard let mappings = self.mappingAndSlideInfos else { return nil }
+        return findMapping(
+            in: mappings,
+            containing: offset,
+            sortedBy: \DyldCacheMappingAndSlideInfo.fileOffset,
+            size: \DyldCacheMappingAndSlideInfo.size
+        )
+    }
+}
+
+extension FullDyldCache {
+    private static let mappingBinarySearchThreshold = 32
+
+    @inline(__always)
+    private func findMapping<C: RandomAccessCollection>(
+        in mappings: C,
+        containing value: UInt64,
+        sortedBy lowerBound: KeyPath<C.Element, UInt64>,
+        size: KeyPath<C.Element, UInt64>
+    ) -> C.Element? {
+        if mappings.count < Self.mappingBinarySearchThreshold {
+            return linearFindMapping(
+                in: mappings,
+                containing: value,
+                lowerBound: lowerBound,
+                size: size
+            )
+        }
+        return binaryFindMapping(
+            in: mappings,
+            containing: value,
+            sortedBy: lowerBound,
+            size: size
+        )
+    }
+
+    @inline(__always)
+    private func linearFindMapping<C: Collection>(
+        in mappings: C,
+        containing value: UInt64,
+        lowerBound: KeyPath<C.Element, UInt64>,
+        size: KeyPath<C.Element, UInt64>
+    ) -> C.Element? {
+        for mapping in mappings {
+            let start = mapping[keyPath: lowerBound]
+            if value >= start && value - start < mapping[keyPath: size] {
+                return mapping
+            }
+        }
+        return nil
+    }
+
+    @inline(__always)
+    private func binaryFindMapping<C: RandomAccessCollection>(
+        in mappings: C,
+        containing value: UInt64,
+        sortedBy lowerBound: KeyPath<C.Element, UInt64>,
+        size: KeyPath<C.Element, UInt64>
+    ) -> C.Element? {
+        var lower = mappings.startIndex
+        var upper = mappings.endIndex
+
+        while lower != upper {
+            let distance = mappings.distance(from: lower, to: upper)
+            let middle = mappings.index(lower, offsetBy: distance / 2)
+
+            if mappings[middle][keyPath: lowerBound] <= value {
+                lower = mappings.index(after: middle)
+            } else {
+                upper = middle
+            }
+        }
+
+        guard lower != mappings.startIndex else { return nil }
+
+        let candidate = mappings[mappings.index(before: lower)]
+        let start = candidate[keyPath: lowerBound]
+        return value >= start && value - start < candidate[keyPath: size] ? candidate : nil
+    }
+}

--- a/Sources/MachOKit/Protocol/DyldCacheRepresentable.swift
+++ b/Sources/MachOKit/Protocol/DyldCacheRepresentable.swift
@@ -192,8 +192,9 @@ extension DyldCacheRepresentable {
     public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
         guard let mappings = self.mappingInfos else { return nil }
         for mapping in mappings {
-            if mapping.address <= address,
-               address < mapping.address + mapping.size {
+            let start = mapping.address
+            if start <= address,
+               address - start < mapping.size {
                 return mapping
             }
         }
@@ -205,8 +206,9 @@ extension DyldCacheRepresentable {
     ) -> DyldCacheMappingInfo? {
         guard let mappings = self.mappingInfos else { return nil }
         for mapping in mappings {
-            if mapping.fileOffset <= offset,
-               offset < mapping.fileOffset + mapping.size {
+            let start = mapping.fileOffset
+            if start <= offset,
+               offset - start < mapping.size {
                 return mapping
             }
         }
@@ -218,8 +220,9 @@ extension DyldCacheRepresentable {
     ) -> DyldCacheMappingAndSlideInfo? {
         guard let mappings = self.mappingAndSlideInfos else { return nil }
         for mapping in mappings {
-            if mapping.address <= address,
-               address < mapping.address + mapping.size {
+            let start = mapping.address
+            if start <= address,
+               address - start < mapping.size {
                 return mapping
             }
         }
@@ -231,8 +234,9 @@ extension DyldCacheRepresentable {
     ) -> DyldCacheMappingAndSlideInfo? {
         guard let mappings = self.mappingAndSlideInfos else { return nil }
         for mapping in mappings {
-            if mapping.fileOffset <= offset,
-               offset < mapping.fileOffset + mapping.size {
+            let start = mapping.fileOffset
+            if start <= offset,
+               offset - start < mapping.size {
                 return mapping
             }
         }

--- a/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
+++ b/Sources/MachOKit/Protocol/_DyldCacheFileRepresentable.swift
@@ -32,8 +32,9 @@ extension _DyldCacheFileRepresentable {
     public func mappingInfo(for address: UInt64) -> DyldCacheMappingInfo? {
         guard let mappings = mappingInfos else { return nil }
         for mapping in mappings {
-            if mapping.address <= address,
-               address < mapping.address + mapping.size {
+            let start = mapping.address
+            if start <= address,
+               address - start < mapping.size {
                 return mapping
             }
         }
@@ -46,8 +47,9 @@ extension _DyldCacheFileRepresentable {
     ) -> DyldCacheMappingInfo? {
         guard let mappings = mappingInfos else { return nil }
         for mapping in mappings {
-            if mapping.fileOffset <= offset,
-               offset < mapping.fileOffset + mapping.size {
+            let start = mapping.fileOffset
+            if start <= offset,
+               offset - start < mapping.size {
                 return mapping
             }
         }
@@ -60,8 +62,9 @@ extension _DyldCacheFileRepresentable {
     ) -> DyldCacheMappingAndSlideInfo? {
         guard let mappings = mappingAndSlideInfos else { return nil }
         for mapping in mappings {
-            if mapping.address <= address,
-               address < mapping.address + mapping.size {
+            let start = mapping.address
+            if start <= address,
+               address - start < mapping.size {
                 return mapping
             }
         }
@@ -74,8 +77,9 @@ extension _DyldCacheFileRepresentable {
     ) -> DyldCacheMappingAndSlideInfo? {
         guard let mappings = mappingAndSlideInfos else { return nil }
         for mapping in mappings {
-            if mapping.fileOffset <= offset,
-               offset < mapping.fileOffset + mapping.size {
+            let start = mapping.fileOffset
+            if start <= offset,
+               offset - start < mapping.size {
                 return mapping
             }
         }


### PR DESCRIPTION
## Summary

- Override `FullDyldCache` mapping lookups with a hybrid linear/binary search helper.
- Keep small mapping lists on the linear path and switch to binary search at 64 mappings.
- Avoid unsigned overflow in dyld cache mapping containment checks by comparing `value - start < size` after `start <= value`.

## Rationale

`FullDyldCache` concatenates mapping arrays from the main cache and subcaches, so mapping lookup can become a repeated hot path for address/file-offset translation and rebase resolution. A pure linear scan is still better for small mapping arrays, while larger arrays benefit from binary search.

The threshold is set to 64 based on a local release benchmark that compared synthetic mapping counts from 4 through 1024. Linear lookup was still faster at 32 and 48 mappings, binary search became competitive around 64, and binary search clearly won from 96 mappings upward.

The helper accepts closure arguments rather than storing `KeyPath<C.Element, UInt64>` and reading via `mapping[keyPath:]`. Call sites can still pass key-path literals such as `\DyldCacheMappingInfo.address`, but Swift treats them as `(Element) -> UInt64` closures at the helper boundary. This avoided the slow dynamic-member keyPath path seen with `LayoutWrapper` types.

## Benchmark Notes

Temporary release benchmark under `/private/tmp/machokit-mapping-bench`:

- Actual `FullDyldCache.host.mappingInfos` count: 15
- Actual linear keyPath: ~10.996 s
- Actual linear closure: ~8.292 ms
- Actual binary keyPath: ~5.875 s
- Actual binary closure: ~16.073 ms

Synthetic mapping-count sweep:

- 32 mappings: linear still faster than binary
- 48 mappings: linear still generally faster
- 64 mappings: binary becomes competitive
- 96+ mappings: binary becomes faster

Package benchmark after the change:

- `FullDyldCache.mappingInfo.lookup`
- Wall clock p50: ~3650 us
- Instructions p50: 56M

## Validation

- `swift build`
- `make benchmark BENCHMARK_ARGS='--filter FullDyldCache.mappingInfo.lookup'`

## Notes

The working tree still has unrelated benchmark/package changes that are not part of this branch diff.