### PR TITLE
Add FullDyldCache address-to-subcache offset lookup APIs

### DIFF
--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -215,7 +215,7 @@ extension FullDyldCache {
             }
             .compactMap { (imagePath: String, fileOffset: UInt64) ->
                 MachOFile? in
-                guard let index = self.fileIndex(forOffset: fileOffset) else {
+                guard let index = self.fileIndex(forFileOffset: fileOffset) else {
                     return nil
                 }
                 let cache = self.cache(atIndex: index, mainCache: mainCache)
@@ -235,7 +235,7 @@ extension FullDyldCache {
         guard let fileOffset = fileOffset(of: header.dyldInCacheMH) else {
             return nil
         }
-        guard let (cache, segment) = cacheAndFileSegment(forOffset: fileOffset) else {
+        guard let (cache, segment) = cacheAndFileSegment(forFileOffset: fileOffset) else {
             return nil
         }
         return try? MachOFile(
@@ -269,35 +269,50 @@ extension FullDyldCache {
 }
 
 extension FullDyldCache {
-    public func url(forOffset offset: UInt64) -> URL? {
-        guard let index = fileIndex(forOffset: offset) else { return nil }
+    /// Returns the cache file URL that contains the specified file offset in the full cache.
+    /// - Parameter fileOffset: A file offset from the start of the full cache's concatenated file view.
+    /// - Returns: The cache file URL that contains `fileOffset`, or `nil` if the offset is outside the full cache.
+    public func url(forFileOffset fileOffset: UInt64) -> URL? {
+        guard let index = fileIndex(forFileOffset: fileOffset) else { return nil }
         return urls[index]
     }
 
-    internal func fileSegment(forOffset offset: UInt64) -> File.FileSegment? {
-        try? fileHandle._file(for: numericCast(offset))
+    /// Returns the file segment that contains the specified file offset in the full cache.
+    /// - Parameter fileOffset: A file offset from the start of the full cache's concatenated file view.
+    /// - Returns: The file segment that contains `fileOffset`, or `nil` if the offset is outside the full cache.
+    internal func fileSegment(forFileOffset fileOffset: UInt64) -> File.FileSegment? {
+        try? fileHandle._file(for: numericCast(fileOffset))
     }
 
-    internal func urlAndFileSegment(forOffset offset: UInt64) -> (URL, File.FileSegment)? {
-        guard let index = fileIndex(forOffset: offset) else { return nil }
+    /// Returns the cache file URL and file segment that contain the specified file offset in the full cache.
+    /// - Parameter fileOffset: A file offset from the start of the full cache's concatenated file view.
+    /// - Returns: The cache file URL and file segment that contain `fileOffset`, or `nil` if the offset is outside the full cache.
+    internal func urlAndFileSegment(forFileOffset fileOffset: UInt64) -> (URL, File.FileSegment)? {
+        guard let index = fileIndex(forFileOffset: fileOffset) else { return nil }
         return (urls[index], fileHandle._files[index])
     }
 
-    internal func cacheAndFileSegment(forOffset offset: UInt64) -> (DyldCache, File.FileSegment)? {
-        guard let index = fileIndex(forOffset: offset) else { return nil }
+    /// Returns the cache and file segment that contain the specified file offset in the full cache.
+    /// - Parameter fileOffset: A file offset from the start of the full cache's concatenated file view.
+    /// - Returns: The cache and file segment that contain `fileOffset`, or `nil` if the offset is outside the full cache.
+    internal func cacheAndFileSegment(forFileOffset fileOffset: UInt64) -> (DyldCache, File.FileSegment)? {
+        guard let index = fileIndex(forFileOffset: fileOffset) else { return nil }
         return (cache(atIndex: index), fileHandle._files[index])
     }
 
-    private func fileIndex(forOffset offset: UInt64) -> Int? {
+    private func fileIndex(forFileOffset fileOffset: UInt64) -> Int? {
         fileHandle._files.firstIndex(
             where: {
-                $0.offset <= offset && offset < $0.offset + $0.size
+                $0.offset <= fileOffset && fileOffset < $0.offset + $0.size
             }
         )
     }
 
-    public func cache(forOffset offset: UInt64) -> DyldCache? {
-        guard let index = fileIndex(forOffset: offset) else { return nil }
+    /// Returns the cache file that contains the specified file offset in the full cache.
+    /// - Parameter fileOffset: A file offset from the start of the full cache's concatenated file view.
+    /// - Returns: The `DyldCache` that contains `fileOffset`, or `nil` if the offset is outside the full cache.
+    public func cache(forFileOffset fileOffset: UInt64) -> DyldCache? {
+        guard let index = fileIndex(forFileOffset: fileOffset) else { return nil }
         return cache(atIndex: index)
     }
 
@@ -315,7 +330,7 @@ extension FullDyldCache {
         for address: UInt64
     ) -> (cache: DyldCache, fileOffset: UInt64)? {
         guard let offset = fileOffset(of: address),
-              let (cache, segment) = cacheAndFileSegment(forOffset: offset) else {
+              let (cache, segment) = cacheAndFileSegment(forFileOffset: offset) else {
             return nil
         }
         return (cache, offset - numericCast(segment.offset))
@@ -324,6 +339,33 @@ extension FullDyldCache {
     public func cache(for url: URL) -> DyldCache? {
         guard let index = urls.firstIndex(of: url) else { return nil }
         return cache(atIndex: index)
+    }
+}
+
+extension FullDyldCache {
+    @available(*, deprecated, renamed: "url(forFileOffset:)")
+    public func url(forOffset offset: UInt64) -> URL? {
+        url(forFileOffset: offset)
+    }
+
+    @available(*, deprecated, renamed: "fileSegment(forFileOffset:)")
+    internal func fileSegment(forOffset offset: UInt64) -> File.FileSegment? {
+        fileSegment(forFileOffset: offset)
+    }
+
+    @available(*, deprecated, renamed: "urlAndFileSegment(forFileOffset:)")
+    internal func urlAndFileSegment(forOffset offset: UInt64) -> (URL, File.FileSegment)? {
+        urlAndFileSegment(forFileOffset: offset)
+    }
+
+    @available(*, deprecated, renamed: "cacheAndFileSegment(forFileOffset:)")
+    internal func cacheAndFileSegment(forOffset offset: UInt64) -> (DyldCache, File.FileSegment)? {
+        cacheAndFileSegment(forFileOffset: offset)
+    }
+
+    @available(*, deprecated, renamed: "cache(forFileOffset:)")
+    public func cache(forOffset offset: UInt64) -> DyldCache? {
+        cache(forFileOffset: offset)
     }
 }
 

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -301,6 +301,26 @@ extension FullDyldCache {
         return cache(atIndex: index)
     }
 
+    /// Returns the cache file that contains the specified unslid address.
+    /// - Parameter address: The unslid virtual memory address.
+    /// - Returns: The `DyldCache` that contains `address`, or `nil` if the address is not mapped.
+    public func cache(for address: UInt64) -> DyldCache? {
+        cacheAndFileOffset(for: address)?.cache
+    }
+
+    /// Converts an unslid address into the cache that contains it and the file offset within that cache.
+    /// - Parameter address: The unslid virtual memory address.
+    /// - Returns: The cache that contains `address` and the file offset relative to the start of that cache file.
+    public func cacheAndFileOffset(
+        for address: UInt64
+    ) -> (cache: DyldCache, fileOffset: UInt64)? {
+        guard let offset = fileOffset(of: address),
+              let (cache, segment) = cacheAndFileSegment(forOffset: offset) else {
+            return nil
+        }
+        return (cache, offset - numericCast(segment.offset))
+    }
+
     public func cache(for url: URL) -> DyldCache? {
         guard let index = urls.firstIndex(of: url) else { return nil }
         return cache(atIndex: index)

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -773,7 +773,7 @@ extension MachOFile {
                     of: numericCast(linkedit.virtualMemoryAddress + offset)
                   ),
                   let segment = fullCache.fileSegment(
-                    forOffset: fileOffset
+                    forFileOffset: fileOffset
                   ) else {
                 return nil
             }

--- a/Sources/MachOKit/Model/DyldCache/DyldCacheLocalSymbolsInfo.swift
+++ b/Sources/MachOKit/Model/DyldCache/DyldCacheLocalSymbolsInfo.swift
@@ -87,7 +87,7 @@ extension DyldCacheLocalSymbolsInfo {
     /// - Returns: Sequence of symbols
     public func symbols64(in cache: FullDyldCache) -> MachOFile.Symbols64? {
         guard let cache = cache.cache(
-            forOffset: cache.header.localSymbolsOffset + numericCast(layout.stringsOffset)
+            forFileOffset: cache.header.localSymbolsOffset + numericCast(layout.stringsOffset)
         ) else {
             return nil
         }
@@ -99,7 +99,7 @@ extension DyldCacheLocalSymbolsInfo {
     /// - Returns: Sequence of symbols
     public func symbols32(in cache: FullDyldCache) -> MachOFile.Symbols? {
         guard let cache = cache.cache(
-            forOffset: cache.header.localSymbolsOffset + numericCast(layout.stringsOffset)
+            forFileOffset: cache.header.localSymbolsOffset + numericCast(layout.stringsOffset)
         ) else {
             return nil
         }

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderInfoRO.swift
@@ -154,7 +154,7 @@ extension ObjCHeaderInfoRO64 {
         in cache: FullDyldCache
     ) -> MachOFile? {
         guard let offset = resolvedMachOHeaderOffset(in: cache),
-              let (_cache, segment) = cache.cacheAndFileSegment(forOffset: offset) else {
+              let (_cache, segment) = cache.cacheAndFileSegment(forFileOffset: offset) else {
             return nil
         }
         let imagePath = imagePath(in: cache)
@@ -262,7 +262,7 @@ extension ObjCHeaderInfoRO32 {
         in cache: FullDyldCache
     ) -> MachOFile? {
         guard let offset = resolvedMachOHeaderOffset(in: cache),
-              let (_cache, segment) = cache.cacheAndFileSegment(forOffset: offset) else {
+              let (_cache, segment) = cache.cacheAndFileSegment(forFileOffset: offset) else {
             return nil
         }
         let imagePath = imagePath(in: cache)

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
@@ -235,7 +235,7 @@ extension ObjCHeaderOptimizationROProtocol {
                     guard let offset = $0.resolvedMachOHeaderOffset(
                         in: cache
                     ),
-                          let (url, segment) = cache.urlAndFileSegment(forOffset: offset) else {
+                          let (url, segment) = cache.urlAndFileSegment(forFileOffset: offset) else {
                         return false
                     }
                     return machO.headerStartOffsetInCache == Int(offset) - segment.offset && machO.url == url


### PR DESCRIPTION
## Summary
- add `FullDyldCache.cache(for:)` and `cacheAndFileOffset(for:)` for resolving an unslid address to the containing dyld cache file
- return the file offset relative to that containing cache, computed from the full-cache file offset and file segment
- rename full-cache concatenated file-offset helpers to `forFileOffset`, keeping the old `forOffset` forms as deprecated compatibility wrappers

## Validation
- `swift build`
- `git diff main...HEAD --check`

## Self-review
- Confirmed internal call sites use the new `forFileOffset` labels, so the build does not emit deprecation warnings.
- Confirmed `cache(for:)` delegates to `cacheAndFileOffset(for:)` instead of duplicating address lookup logic.
- Confirmed `cacheAndFileOffset(for:)` avoids a second address-to-file-offset lookup by deriving the per-cache file offset from the full-cache file offset and file segment.