### PR TITLE
Avoid KeyPath overhead in full cache mapping lookup

### DIFF
--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -396,8 +396,8 @@ extension FullDyldCache {
         return findMapping(
             in: mappings,
             containing: address,
-            sortedBy: \DyldCacheMappingInfo.address,
-            size: \DyldCacheMappingInfo.size
+            sortedBy: { $0.address },
+            size: { $0.size }
         )
     }
 
@@ -408,8 +408,8 @@ extension FullDyldCache {
         return findMapping(
             in: mappings,
             containing: offset,
-            sortedBy: \DyldCacheMappingInfo.fileOffset,
-            size: \DyldCacheMappingInfo.size
+            sortedBy: { $0.fileOffset },
+            size: { $0.size }
         )
     }
 
@@ -420,8 +420,8 @@ extension FullDyldCache {
         return findMapping(
             in: mappings,
             containing: address,
-            sortedBy: \DyldCacheMappingAndSlideInfo.address,
-            size: \DyldCacheMappingAndSlideInfo.size
+            sortedBy: { $0.address },
+            size: { $0.size }
         )
     }
 
@@ -432,8 +432,8 @@ extension FullDyldCache {
         return findMapping(
             in: mappings,
             containing: offset,
-            sortedBy: \DyldCacheMappingAndSlideInfo.fileOffset,
-            size: \DyldCacheMappingAndSlideInfo.size
+            sortedBy: { $0.fileOffset },
+            size: { $0.size }
         )
     }
 }


### PR DESCRIPTION
## Summary

- replace KeyPath literals passed to `FullDyldCache` mapping lookup helpers with explicit closures
- avoid dynamic KeyPath access overhead while preserving the existing linear/binary search behavior

## Why

The mapping helpers accept closures, but passing `\Type.property` at the call sites retained expensive KeyPath access for the C-backed mapping wrapper properties. This caused `FullDyldCache.mappingInfo.lookup` to execute roughly 11G instructions instead of about 62M.

Using explicit closures such as `{ $0.address }` allows the property access to be optimized normally. The search threshold, ordering assumptions, containment checks, and public behavior are unchanged.

## Benchmark

`FullDyldCache.mappingInfo.lookup`:

| Measurement | Wall-clock p50 | Instructions p50 |
|---|---:|---:|
| Before fix | ~571 ms | ~11G |
| After fix | 3.301 ms | 56M |
| 0.51.0 live comparison | 3.254 ms | 62M |

The fixed implementation removes the regression and uses about 10% fewer instructions than 0.51.0. The remaining ~1.4% wall-clock difference is within observed run-to-run variation.

## Validation

- `git diff --cached --check`
- `make benchmark-baseline-compare BASELINE=0.51.0 'BENCHMARK_ARGS=--filter FullDyldCache.mappingInfo.lookup'`
- live focused benchmark from the 0.51.0 tag under the same current environment