### PR TITLE
Add FullDyldCache mapping lookup benchmark

### DIFF
--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/Fixtures.swift
@@ -170,6 +170,27 @@ enum BenchmarkFixtures {
         }
     }
 
+    static func dyldCacheAddressesAcrossMappings(
+        from cache: some DyldCacheRepresentable,
+        limit: Int
+    ) -> [UInt64] {
+        guard let mappings = cache.mappingInfos,
+              !mappings.isEmpty else {
+            return []
+        }
+
+        return (0..<limit).compactMap { index in
+            let mapping = mappings[
+                mappings.index(
+                    mappings.startIndex,
+                    offsetBy: index % mappings.count
+                )
+            ]
+            guard mapping.size > 0 else { return nil }
+            return mapping.address + UInt64(index) % mapping.size
+        }
+    }
+
     static func dyldCacheFileOffsetsAcrossMappings(
         from cache: some DyldCacheRepresentable,
         limit: Int

--- a/Benchmarks/Benchmarks/MachOKitBenchmarks/FullDyldCacheBenchmarks.swift
+++ b/Benchmarks/Benchmarks/MachOKitBenchmarks/FullDyldCacheBenchmarks.swift
@@ -46,6 +46,29 @@ func registerFullDyldCacheBenchmarks() {
         }
     }
 
+    Benchmark("FullDyldCache.mappingInfo.lookupAcrossMappings") { benchmark in
+        guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
+        let addresses = BenchmarkFixtures.dyldCacheAddressesAcrossMappings(
+            from: cache,
+            limit: 100_000
+        )
+        let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsetsAcrossMappings(
+            from: cache,
+            limit: 100_000
+        )
+
+        benchmark.startMeasurement()
+
+        for address in addresses {
+            blackHole(cache.mappingInfo(for: address))
+            blackHole(cache.mappingAndSlideInfo(for: address))
+        }
+        for fileOffset in fileOffsets {
+            blackHole(cache.mappingInfo(forFileOffset: fileOffset))
+            blackHole(cache.mappingAndSlideInfo(forFileOffset: fileOffset))
+        }
+    }
+
     Benchmark("FullDyldCache.cache.forOffset") { benchmark in
         guard let cache = BenchmarkFixtures.fullDyldCache() else { return }
         let fileOffsets = BenchmarkFixtures.dyldCacheFileOffsetsAcrossMappings(from: cache, limit: 100_000)


### PR DESCRIPTION
## Summary

- add a FullDyldCache mapping lookup benchmark that distributes inputs across every mapping
- add an address fixture helper matching the existing across-mappings file-offset fixture

## Why

The existing mapping lookup benchmark only generated inputs from the first mapping. That makes comparison between linear and binary lookup strategies depend on the first-hit best case rather than the full cache mapping distribution.

## Impact

The new benchmark exercises address and file-offset lookups for both mapping-info variants across all mappings, making the performance comparison representative of global lookup behavior.

## Validation

- `swift build`
- `git diff --check`
- compared the benchmark against the 0.51.0 baseline using the iPhone18,2 FullDyldCache fixture