### PR TITLE
Fix benchmark workflow package identity

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,14 +51,16 @@ jobs:
       - name: Checkout candidate
         uses: actions/checkout@v4
         with:
-          path: candidate
+          # Benchmarks uses `.package(path: "..")` with the MachOKit identity.
+          path: candidate/MachOKit
 
       - name: Checkout baseline
         if: inputs.mode == 'compare'
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.baseline_ref }}
-          path: baseline
+          # Keep the local package identity consistent with the candidate.
+          path: baseline/MachOKit
 
       - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
@@ -66,11 +68,11 @@ jobs:
       - name: Run benchmark workflow
         shell: bash
         env:
-          CANDIDATE_ROOT: ${{ github.workspace }}/candidate
-          BASELINE_ROOT: ${{ github.workspace }}/baseline
+          CANDIDATE_ROOT: ${{ github.workspace }}/candidate/MachOKit
+          BASELINE_ROOT: ${{ github.workspace }}/baseline/MachOKit
           BENCHMARK_RESULTS_DIR: ${{ runner.temp }}/benchmark-results
           MACHOKIT_BENCH_MACHO: ${{ runner.temp }}/MachOKitBenchmarks-fixture
-        run: bash candidate/scripts/benchmark.sh
+        run: bash candidate/MachOKit/scripts/benchmark.sh
 
       - name: Upload benchmark results
         if: always()


### PR DESCRIPTION
## Summary

- check out both benchmark refs under directories named `MachOKit`
- update candidate and baseline root variables to match the nested checkout paths
- invoke the reusable benchmark script from its new candidate path

## Root cause

`Benchmarks/Package.swift` declares the repository with `.package(path: "..")` and references the product with `package: "MachOKit"`. SwiftPM derives the identity of that local dependency from its directory name. The workflow checked the repository out as `candidate` and `baseline`, so the candidate dependency was identified as `candidate` instead of `MachOKit` and dependency resolution failed.

## Impact

Manual single-ref and comparison benchmark runs can now resolve the local MachOKit package in GitHub Actions without changing the benchmark package manifest.

## Validation

- parsed `.github/workflows/benchmark.yml` as YAML
- ran `bash -n scripts/benchmark.sh`
- verified all candidate and baseline roots use paths ending in `MachOKit`
- ran `git diff --check`

The workflow still needs to be re-run on GitHub Actions to verify the hosted-runner execution end to end.