### PR TITLE
Use Xcode 26 for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
   BENCHMARK_DISABLE_JEMALLOC: "1"
 
 jobs:
   benchmark:
     name: ${{ inputs.mode == 'compare' && 'Compare refs' || 'Run benchmarks' }}
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 120
     env:
       BENCHMARK_MODE: ${{ inputs.mode }}
@@ -62,8 +62,8 @@ jobs:
           # Keep the local package identity consistent with the candidate.
           path: baseline/MachOKit
 
-      - name: Select Xcode 16.2
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Select Xcode 26.6
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Run benchmark workflow
         shell: bash


### PR DESCRIPTION
## Summary

- move the benchmark job from the `macos-15` runner to `macos-26`
- pin `DEVELOPER_DIR` to Xcode 26.6
- explicitly select `/Applications/Xcode_26.6.app` before running benchmarks

## Why

Benchmark runs should use the current Xcode 26 toolchain while keeping the compiler version explicit and repeatable. The GitHub `macos-26` runner image includes Xcode 26.6 at the pinned path.

Runner image reference: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md

## Impact

Both candidate and baseline measurements continue to run in the same job and therefore use the same macOS runner and Xcode 26.6 toolchain.

## Validation

- parsed `.github/workflows/benchmark.yml` as YAML
- ran `bash -n scripts/benchmark.sh`
- verified the runner, `DEVELOPER_DIR`, and `xcode-select` path consistently target macOS/Xcode 26
- verified no Xcode 16.2 or `macos-15` references remain
- ran `git diff --check`

The workflow still needs an end-to-end run on GitHub Actions.