### PR TITLE
Cache file handle identity on initialization

### DIFF
--- a/Sources/MachOKit/AotCache.swift
+++ b/Sources/MachOKit/AotCache.swift
@@ -21,6 +21,7 @@ public struct AotCache {
     /// URL of loaded dyld cache file
     public let url: URL
     let fileHandle: File
+    let _fileHandleIdentity: FileHandleIdentityBox
 
 //    public var headerSize: Int {
 //        header.headerSize
@@ -36,6 +37,9 @@ public struct AotCache {
             isWritable: false
         )
         self.fileHandle = fileHandle
+        self._fileHandleIdentity = FileHandleIdentityStore.identity(
+            for: fileHandle
+        )
 
         // read header
         self.header = try! fileHandle.read(

--- a/Sources/MachOKit/DyldCache.swift
+++ b/Sources/MachOKit/DyldCache.swift
@@ -34,6 +34,7 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
     /// URL of loaded dyld cache file
     public let url: URL
     let fileHandle: File
+    let _fileHandleIdentity: FileHandleIdentityBox
 
     // Retain the cache to which `self` belongs
     internal var _fullCache: FullDyldCache?
@@ -77,6 +78,9 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
             isWritable: false
         )
         self.fileHandle = fileHandle
+        self._fileHandleIdentity = FileHandleIdentityStore.identity(
+            for: fileHandle
+        )
 
         // read header
         self.header = try! fileHandle.read(
@@ -132,6 +136,9 @@ public class DyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable {
         mainCacheHeader: DyldCacheHeader? = nil
     ) {
         self.fileHandle = fileHandle
+        self._fileHandleIdentity = FileHandleIdentityStore.identity(
+            for: fileHandle
+        )
         self.url = url
         self.header = header ?? (
             try! fileHandle.read(

--- a/Sources/MachOKit/FullDyldCache.swift
+++ b/Sources/MachOKit/FullDyldCache.swift
@@ -32,6 +32,7 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
     /// URL of loaded dyld cache file
     public let url: URL
     let fileHandle: File
+    let _fileHandleIdentity: FileHandleIdentityBox
 
     // Retain the symbol cache
     private var _symbolCache: DyldCache?
@@ -77,6 +78,9 @@ public class FullDyldCache: DyldCacheRepresentable, _DyldCacheFileRepresentable 
             isWritable: false
         )
         self.fileHandle = fileHandle
+        self._fileHandleIdentity = FileHandleIdentityStore.identity(
+            for: fileHandle
+        )
         self.header = mainCache.header
         self.cpu = mainCache.cpu
         self.subCacheSuffixes = subCacheSuffixes

--- a/Sources/MachOKit/MachOFile.swift
+++ b/Sources/MachOKit/MachOFile.swift
@@ -24,6 +24,7 @@ public class MachOFile: MachORepresentable {
     private let _imagePath: String?
 
     let fileHandle: File
+    let _fileHandleIdentity: FileHandleIdentityBox
 
     // Retain the cache to which `self` belongs
     private var _fullCache: FullDyldCache?
@@ -137,6 +138,9 @@ public class MachOFile: MachORepresentable {
         self.url = url
         self._imagePath = imagePath
         self.fileHandle = fileHandle
+        self._fileHandleIdentity = FileHandleIdentityStore.identity(
+            for: fileHandle
+        )
         self._cache = cache
 
         self.headerStartOffset = headerStartOffset

--- a/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
+++ b/Sources/MachOKit/Support/MachOKit+FileIdentity.swift
@@ -85,7 +85,7 @@ extension MachOFile {
     @_spi(Support)
     @inline(__always)
     public var fileHandleIdentity: any FileHandleIdentity {
-        FileHandleIdentityStore.identity(for: fileHandle)
+        _fileHandleIdentity
     }
 }
 
@@ -98,7 +98,7 @@ extension DyldCache {
     @_spi(Support)
     @inline(__always)
     public var fileHandleIdentity: any FileHandleIdentity {
-        FileHandleIdentityStore.identity(for: fileHandle)
+        _fileHandleIdentity
     }
 }
 
@@ -111,7 +111,7 @@ extension FullDyldCache {
     @_spi(Support)
     @inline(__always)
     public var fileHandleIdentity: any FileHandleIdentity {
-        FileHandleIdentityStore.identity(for: fileHandle)
+        _fileHandleIdentity
     }
 }
 
@@ -124,6 +124,6 @@ extension AotCache {
     @_spi(Support)
     @inline(__always)
     public var fileHandleIdentity: any FileHandleIdentity {
-        FileHandleIdentityStore.identity(for: fileHandle)
+        _fileHandleIdentity
     }
 }


### PR DESCRIPTION
## Summary

- Resolve and retain each backing file handle's `FileHandleIdentityBox` during wrapper initialization.
- Return the retained token directly from the `fileHandleIdentity` SPI accessor.
- Apply the same behavior to `MachOFile`, `DyldCache`, `FullDyldCache`, and `AotCache` while preserving identity sharing for wrappers backed by the same handle.

## Motivation

Repeated `fileHandleIdentity` access previously acquired a global `NSLock` and performed an `NSMapTable` lookup each time. This became a hot-path regression for clients that use the identity to share handle-scoped caches, especially recursive Objective-C protocol parsing.

Resolving the identity once per wrapper removes that repeated synchronization and lookup cost while retaining the existing backing-handle identity semantics.

## Performance

In the affected `DyldCache.MachOFile.objc.protocolInfo.first100` benchmark:

- instructions p50: **69M → 51M**
- wall-clock p50: **4.248 ms → 3.373 ms**

The previous `0.7.0` baseline measured 53M instructions at p50.

## Validation

- `swift build`
- `git diff --check`
- Local MachOObjCSection build against this MachOKit change
- Focused MachOObjCSection benchmark comparison

The full `swift test` run was started and successfully built/linked the test bundle, but was stopped because the repository's existing print/sample tests emit a very large amount of system-binary output.