### PR TITLE
Fix ObjC header info lookup for subcaches

### DIFF
--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
@@ -210,7 +210,8 @@ extension ObjCHeaderOptimizationROProtocol {
         return headerInfos(in: cache)?
             .first(
                 where: {
-                    guard let offset = $0.resolvedMachOHeaderOffset(in: cache) else {
+                    guard let cacheForMachO = machO.cache,
+                          let offset = $0.resolvedMachOHeaderOffset(in: cacheForMachO) else {
                         return false
                     }
                     return machO.headerStartOffsetInCache == offset

--- a/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
+++ b/Sources/MachOKit/Model/DyldCache/ObjCOptimization/ObjCHeaderOptimizationRO.swift
@@ -204,14 +204,14 @@ extension ObjCHeaderOptimizationROProtocol {
     public func headerInfo(
         in cache: DyldCache, for machO: MachOFile
     ) -> HeaderInfo? {
-        guard machO.headerStartOffsetInCache > 0 else {
+        guard machO.headerStartOffsetInCache > 0,
+              let cacheForMachO = machO.cache else {
             return nil
         }
         return headerInfos(in: cache)?
             .first(
                 where: {
-                    guard let cacheForMachO = machO.cache,
-                          let offset = $0.resolvedMachOHeaderOffset(in: cacheForMachO) else {
+                    guard let offset = $0.resolvedMachOHeaderOffset(in: cacheForMachO) else {
                         return false
                     }
                     return machO.headerStartOffsetInCache == offset


### PR DESCRIPTION
## Summary

- resolve Objective-C header-info Mach-O offsets using the target `MachOFile`'s dyld cache
- preserve the RO optimization table lookup in the cache supplied by the caller

## Root cause

`MachOFile.headerStartOffsetInCache` is local to the cache file that contains the Mach-O image. The lookup previously resolved each Objective-C header entry through the cache containing the RO optimization table. When the target image lived in a subcache, that produced no offset or an offset in the wrong file, so the matching header info could not be found.

## Impact

`ObjCHeaderOptimizationROProtocol.headerInfo(in:for:)` can now find header information for Mach-O files stored in dyld subcaches.

## Validation

- `swift build`
- `swift test --filter FullDyldCachePrintTests/testObjCHeaderOptimizationRO`

## Testing note

The existing focused test validates the full-cache path. A dedicated synthetic regression test for the single-cache overload and a subcache-backed `MachOFile` is not included in this change.